### PR TITLE
fix: break 3-file import cycle in cli/project-files

### DIFF
--- a/cli/src/__tests__/project-files-chat-id.test.ts
+++ b/cli/src/__tests__/project-files-chat-id.test.ts
@@ -8,7 +8,10 @@ import {
   getCurrentChatId,
   setCurrentChatId,
   startNewChat,
+  setProjectRoot,
+  getProjectDataDir,
 } from '../project-files'
+import { getConfigDir } from '../utils/config-dir'
 
 describe('chat id lifecycle', () => {
   test('getCurrentChatId is stable across calls', () => {
@@ -30,5 +33,22 @@ describe('chat id lifecycle', () => {
     expect(getCurrentChatId()).toBe(rotated)
     // New ids are filesystem-safe ISO timestamps
     expect(rotated).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z$/)
+  })
+})
+
+describe('getProjectDataDir', () => {
+  test('returns a path containing the project basename', () => {
+    setProjectRoot('/tmp/my-project')
+    const dataDir = getProjectDataDir()
+    expect(dataDir).toContain('my-project')
+    expect(dataDir).toContain('projects')
+  })
+
+  test('uses config-dir getConfigDir (not auth re-export)', () => {
+    setProjectRoot('/tmp/test-repo')
+    const dataDir = getProjectDataDir()
+    // Should resolve via config-dir's getConfigDir without pulling in auth.ts
+    const configDir = getConfigDir()
+    expect(dataDir).toContain(configDir)
   })
 })

--- a/cli/src/project-files.ts
+++ b/cli/src/project-files.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readdirSync, statSync } from 'fs'
 import path from 'path'
 
-import { getConfigDir } from './utils/auth'
+import { getConfigDir } from './utils/config-dir'
 
 let projectRoot: string | undefined
 let currentChatId: string | undefined


### PR DESCRIPTION
## Summary

Breaks the circular import dependency between `project-files.ts`, `auth.ts`, and `logger.ts`.

**The cycle:**
```
project-files.ts → auth.ts → logger.ts → project-files.ts
```

`project-files.ts` imported `getConfigDir` from `./utils/auth`, which imports `logger`, which imports `getCurrentChatDir` and `getProjectRoot` back from `../project-files` — creating a 3-file circular dependency.

**The fix:** Import `getConfigDir` directly from `./utils/config-dir`, which has no dependency on `auth.ts`, `logger.ts`, or `project-files.ts`.

## Maintainer Feedback Addressed

1. **Same signature?** Yes — `config-dir.ts:14` exports the identical `getConfigDir` function. `auth.ts:37` is a thin wrapper: `export const getConfigDir = (): string => getConfigDirBase()`. No behavior change.

2. **Does the cycle cause a real problem?** Yes — circular dependencies can cause `undefined` values at import time depending on module load order, especially in bundlers or when tree-shaking.

3. **Test coverage** — Added two tests for `getProjectDataDir` in `project-files-chat-id.test.ts` to exercise the fixed import path.

## Notes

- `anonymous-id.ts` already imports `getConfigDir` directly from `config-dir` (this PR aligns `project-files.ts` with that pattern)
- No functional change — `getConfigDir` returns the same value either way