### PR TITLE
fix(cli): sync terminal cursor with input caret for CJK IME

### DIFF
--- a/cli/src/components/__tests__/multiline-input.test.tsx
+++ b/cli/src/components/__tests__/multiline-input.test.tsx
@@ -1,9 +1,21 @@
-import { describe, test, expect } from 'bun:test'
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { createTestRenderer } from '@opentui/core/testing'
+import { createRoot, flushSync } from '@opentui/react'
+import React from 'react'
 
 import {
   getKeypadPrintableSequence,
   isKeypadEnter,
 } from '../../utils/keypad-keys'
+import { initializeThemeStore } from '../../hooks/use-theme'
+import {
+  calculateMultilineInputCursorPosition,
+  MultilineInput,
+} from '../multiline-input'
+
+beforeAll(() => {
+  initializeThemeStore()
+})
 
 /**
  * Tests for tab character cursor rendering in MultilineInput component.
@@ -239,6 +251,187 @@ describe('MultilineInput - tab character handling', () => {
 
     // 'a' (1) + tab (4) + 'b' (1) = 6
     expect(renderPos).toBe(6)
+  })
+})
+
+describe('MultilineInput - hardware cursor coordinates', () => {
+  const viewportX = 10
+  const viewportY = 20
+  const lineInfo = (lineStartCols: number[]) => ({ lineStartCols })
+
+  test('places the ASCII caret using terminal cell columns', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: 'hello',
+        cursorPosition: 2,
+        lineInfo: lineInfo([0]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 0,
+      }),
+    ).toEqual({ x: 13, y: 21 })
+  })
+
+  test('advances two terminal cells after a CJK wide character', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: '你a',
+        cursorPosition: 1,
+        lineInfo: lineInfo([0]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 0,
+      }),
+    ).toEqual({ x: 13, y: 21 })
+  })
+
+  test('handles mixed ASCII and CJK widths', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: 'a你b',
+        cursorPosition: 2,
+        lineInfo: lineInfo([0]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 0,
+      }),
+    ).toEqual({ x: 14, y: 21 })
+  })
+
+  test('uses the existing four-cell tab expansion', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: '\ta',
+        cursorPosition: 1,
+        lineInfo: lineInfo([0]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 0,
+      }),
+    ).toEqual({ x: 15, y: 21 })
+  })
+
+  test('uses cumulative visual-line offsets for wrapped text', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: 'abcdefghij',
+        cursorPosition: 7,
+        lineInfo: lineInfo([0, 5]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 0,
+      }),
+    ).toEqual({ x: 13, y: 22 })
+  })
+
+  test('applies the viewport offset and vertical scroll position', () => {
+    expect(
+      calculateMultilineInputCursorPosition({
+        text: 'a\nb\nc',
+        cursorPosition: 4,
+        lineInfo: lineInfo([0, 2, 4]),
+        viewportX,
+        viewportY,
+        verticalScrollPosition: 1,
+      }),
+    ).toEqual({ x: 11, y: 22 })
+  })
+})
+
+describe('MultilineInput - hardware cursor lifecycle', () => {
+  test('moves the renderer cursor two cells after a CJK character', async () => {
+    const setup = await createTestRenderer({ width: 30, height: 8 })
+    const root = createRoot(setup.renderer)
+
+    try {
+      flushSync(() =>
+        root.render(
+          <MultilineInput
+            value="你a"
+            onChange={() => {}}
+            onSubmit={() => {}}
+            onPaste={() => {}}
+            cursorPosition={1}
+            maxHeight={3}
+            shouldBlinkCursor={false}
+            focused
+          />,
+        ),
+      )
+      await setup.renderOnce()
+
+      expect(setup.renderer.getCursorState()).toMatchObject({
+        x: 4,
+        y: 1,
+        visible: true,
+      })
+    } finally {
+      flushSync(() => root.unmount())
+      setup.renderer.destroy()
+    }
+  })
+
+  test('places the renderer cursor on the wrapped visual row', async () => {
+    const setup = await createTestRenderer({ width: 12, height: 8 })
+    const root = createRoot(setup.renderer)
+    const props = {
+      value: 'one two three',
+      onChange: () => {},
+      onSubmit: () => {},
+      onPaste: () => {},
+      cursorPosition: 13,
+      maxHeight: 5,
+      shouldBlinkCursor: false,
+      focused: true,
+    }
+
+    try {
+      flushSync(() => root.render(<MultilineInput {...props} />))
+      await setup.renderOnce()
+
+      // The wrapped second line is scrolled into the top viewport row.
+      expect(setup.renderer.getCursorState()).toMatchObject({
+        x: 7,
+        y: 1,
+        visible: true,
+      })
+    } finally {
+      flushSync(() => root.unmount())
+      setup.renderer.destroy()
+    }
+  })
+
+  test('hides the hardware cursor when unfocused and on unmount', async () => {
+    const setup = await createTestRenderer({ width: 30, height: 8 })
+    const root = createRoot(setup.renderer)
+    const props = {
+      value: 'input',
+      onChange: () => {},
+      onSubmit: () => {},
+      onPaste: () => {},
+      cursorPosition: 2,
+      maxHeight: 3,
+      shouldBlinkCursor: false,
+    }
+
+    try {
+      flushSync(() => root.render(<MultilineInput {...props} focused />))
+      await setup.renderOnce()
+      expect(setup.renderer.getCursorState().visible).toBe(true)
+
+      flushSync(() => root.render(<MultilineInput {...props} focused={false} />))
+      await setup.renderOnce()
+      expect(setup.renderer.getCursorState().visible).toBe(false)
+
+      flushSync(() => root.render(<MultilineInput {...props} focused />))
+      await setup.renderOnce()
+      expect(setup.renderer.getCursorState().visible).toBe(true)
+
+      flushSync(() => root.unmount())
+      expect(setup.renderer.getCursorState().visible).toBe(false)
+    } finally {
+      setup.renderer.destroy()
+    }
   })
 })
 

--- a/cli/src/components/multiline-input.tsx
+++ b/cli/src/components/multiline-input.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import stringWidth from 'string-width'
 
 import { InputCursor } from './input-cursor'
 import { useTheme } from '../hooks/use-theme'
@@ -31,10 +32,10 @@ import { calculateNewCursorPosition } from '../utils/word-wrap-utils'
 import type { InputValue } from '../types/store'
 import type {
   KeyEvent,
+  LineInfo,
   MouseEvent,
   PasteEvent,
   ScrollBoxRenderable,
-  TextBufferView,
   TextRenderable,
 } from '@opentui/core'
 
@@ -94,6 +95,80 @@ function findNextWordBoundary(text: string, cursor: number): number {
 export const CURSOR_CHAR = '▍'
 const CONTROL_CHAR_REGEX = /[\u0000-\u0008\u000b-\u000c\u000e-\u001f\u007f]/
 const TAB_WIDTH = 4
+
+type TextBufferViewWithVisualLineInfo = {
+  lineInfo?: {
+    lineStartCols?: unknown
+  }
+}
+
+/**
+ * Get the visual (wrapped) line info used by this component.
+ *
+ * OpenTUI 0.3.4 publicly exposes logical line info on TextRenderable, but
+ * navigation and layout here already depend on the visual wrapped line info.
+ * Keep that internal dependency in one guarded adapter until OpenTUI exposes
+ * the equivalent visual data publicly.
+ */
+function getVisualLineInfo(
+  textRenderable: TextRenderable | null,
+): Pick<LineInfo, 'lineStartCols'> | null {
+  const textBufferView = (
+    textRenderable as unknown as {
+      textBufferView?: TextBufferViewWithVisualLineInfo
+    } | null
+  )?.textBufferView
+  const lineInfo = textBufferView?.lineInfo
+  const lineStartCols = lineInfo?.lineStartCols
+
+  if (
+    !Array.isArray(lineStartCols) ||
+    !lineStartCols.every((lineStart) => typeof lineStart === 'number')
+  ) {
+    return null
+  }
+
+  return lineInfo as Pick<LineInfo, 'lineStartCols'>
+}
+
+export function calculateMultilineInputCursorPosition({
+  text,
+  cursorPosition,
+  lineInfo,
+  viewportX,
+  viewportY,
+  verticalScrollPosition,
+}: {
+  text: string
+  cursorPosition: number
+  lineInfo: Pick<LineInfo, 'lineStartCols'> | null
+  viewportX: number
+  viewportY: number
+  verticalScrollPosition: number
+}): { x: number; y: number } {
+  const safeCursorPosition = Math.max(0, Math.min(cursorPosition, text.length))
+  const renderedPrefix = text
+    .slice(0, safeCursorPosition)
+    .replace(/\t/g, ' '.repeat(TAB_WIDTH))
+  const displayColumn =
+    stringWidth(renderedPrefix) + (renderedPrefix.match(/\n/g)?.length ?? 0)
+
+  // OpenTUI reports lineStartCols as cumulative display-column offsets for
+  // visual lines. Compare against the rendered width, not the source index.
+  const lineStarts = lineInfo?.lineStartCols ?? [0]
+  const visualRow = Math.max(
+    0,
+    lineStarts.findLastIndex((lineStart) => lineStart <= displayColumn),
+  )
+  const visualLineStart = lineStarts[visualRow] ?? 0
+
+  // OpenTUI's renderer cursor coordinates are 1-based terminal coordinates;
+  // viewport x/y are 0-based screen layout coordinates.
+  return {
+    x: viewportX + displayColumn - visualLineStart + 1,
+    y: viewportY + visualRow - verticalScrollPosition + 1,
+  }
+}
 
 /**
  * Check if a key event represents printable character input (not a special key).
@@ -236,10 +311,12 @@ export const MultilineInput = forwardRef<
   // updated synchronously to ensure each keystroke builds on the previous one.
   const valueRef = useRef(value)
   const cursorPositionRef = useRef(cursorPosition)
+  const focusedRef = useRef(focused)
 
   // Keep refs current on every render (synchronous assignment avoids useEffect timing issues)
   valueRef.current = value
   cursorPositionRef.current = cursorPosition
+  focusedRef.current = focused
 
   // Helper to get or set the sticky column for vertical navigation.
   // When stickyColumnRef.current is set, we return it (preserving column across
@@ -269,12 +346,7 @@ export const MultilineInput = forwardRef<
 
   const textRef = useRef<TextRenderable | null>(null)
 
-  const lineInfo = textRef.current
-    ? (
-        (textRef.current satisfies TextRenderable as any)
-          .textBufferView as TextBufferView
-      ).lineInfo
-    : null
+  const lineInfo = getVisualLineInfo(textRef.current)
 
   // Focus/blur scrollbox when focused prop changes
   const prevFocusedRef = useRef(false)
@@ -513,6 +585,60 @@ export const MultilineInput = forwardRef<
     /\t/g,
     ' '.repeat(TAB_WIDTH),
   )
+  const hardwareCursorTextRef = useRef(displayValue)
+  hardwareCursorTextRef.current = displayValue
+
+  // Keep the terminal's hardware cursor at the same screen-cell position as
+  // the existing visual caret so terminal IMEs can anchor their UI correctly.
+  const syncHardwareCursor = useCallback(() => {
+    if (!focusedRef.current) {
+      renderer.setCursorPosition(0, 0, false)
+      return
+    }
+
+    const scrollBox = scrollBoxRef.current
+    const lineInfo = getVisualLineInfo(textRef.current)
+
+    if (!scrollBox || !lineInfo) {
+      renderer.setCursorPosition(0, 0, false)
+      return
+    }
+
+    const viewport = scrollBox.viewport
+    const cursor = calculateMultilineInputCursorPosition({
+      text: hardwareCursorTextRef.current,
+      cursorPosition: cursorPositionRef.current,
+      lineInfo,
+      viewportX: Number(viewport.x),
+      viewportY: Number(viewport.y),
+      verticalScrollPosition: scrollBox.verticalScrollBar.scrollPosition,
+    })
+
+    renderer.setCursorPosition(cursor.x, cursor.y, true)
+  }, [renderer])
+
+  useEffect(() => {
+    syncHardwareCursor()
+  }, [focused, displayValue, cursorPosition, lineInfo, syncHardwareCursor])
+
+  useEffect(() => {
+    if (!focused) return
+
+    // React effects can run before OpenTUI has completed the layout pass that
+    // establishes wrapping and viewport coordinates. TextRenderable emits
+    // this event after its line information is recalculated.
+    const textRenderable = textRef.current
+    textRenderable?.on('line-info-change', syncHardwareCursor)
+    return () => {
+      textRenderable?.off('line-info-change', syncHardwareCursor)
+    }
+  }, [focused, syncHardwareCursor])
+
+  useEffect(() => {
+    return () => {
+      renderer.setCursorPosition(0, 0, false)
+    }
+  }, [renderer])
 
   // Calculate cursor position in the expanded string (accounting for tabs)
   let renderCursorPosition = 0
@@ -840,9 +966,7 @@ export const MultilineInput = forwardRef<
       const wordEnd = findNextWordBoundary(value, cursorPosition)
 
       // Read lineInfo inside the callback to get current value (not stale from closure)
-      const currentLineInfo = textRef.current
-        ? ((textRef.current as any).textBufferView as TextBufferView)?.lineInfo
-        : null
+      const currentLineInfo = getVisualLineInfo(textRef.current)
 
       // Calculate visual line boundaries from lineInfo (accounts for word wrap)
       // Fall back to logical line boundaries if visual info is unavailable


### PR DESCRIPTION
## Summary

Recreates #1142 on top of the rewritten `main` history, as requested by the maintainer in the closed PR. Fixes #1128.

The CLI rendered a visual caret but did not move the real terminal hardware cursor to the input position. CJK IMEs use the terminal cursor position to anchor their composition and candidate windows, which caused the popup to appear at unrelated screen locations.

This change:

- synchronizes the real terminal cursor with the `MultilineInput` caret
- accounts for CJK terminal-cell width using `string-width`
- handles tabs, wrapped visual lines, viewport offsets, and vertical scrolling
- hides the hardware cursor when the input loses focus or unmounts
- keeps the existing visual cursor behavior unchanged
- centralizes OpenTUI 0.3.4 visual `textBufferView.lineInfo` access behind a guarded adapter while preserving wrapped-line semantics
- keeps the `line-info-change` subscription stable instead of re-subscribing on ordinary caret/value changes

## Tests

Regression coverage includes:

- ASCII cursor positioning
- CJK wide characters
- mixed ASCII/CJK input
- tab expansion
- wrapped visual lines
- viewport and vertical scroll offsets
- cursor visibility on focus/unmount
- component-level OpenTUI renderer cursor positioning after a CJK character
- renderer-level cursor placement on a wrapped visual row

Validation from #1142:

- `bun test cli/src/components/__tests__/multiline-input.test.tsx` — 81 passed
- repeated focused test run (`--rerun-each 3`) — 243 passed
- `git diff --check` — passed

CLI typecheck was blocked by pre-existing missing `tar` and `react-dom/server` typings; no errors were reported in the changed files.

## Manual verification

Manually verified in Windows Terminal with Microsoft Pinyin. Candidate-window positioning followed the input caret correctly across normal CJK input, cursor movement, wrapped lines, and scrolling.

This branch is rebuilt directly from the current rewritten `main` and contains a single clean commit. Previous review context: #1142.