### PR TITLE
fix(cli): reload MCP config after project selection

### DIFF
--- a/cli/src/__tests__/utils/project-picker.test.ts
+++ b/cli/src/__tests__/utils/project-picker.test.ts
@@ -1,8 +1,26 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import os from 'os'
 import path from 'path'
 
 import { describe, test, expect } from 'bun:test'
 
-import { shouldShowProjectPicker } from '../../utils/project-picker'
+import {
+  getProjectRoot,
+  setProjectRoot,
+  tryGetProjectRoot,
+} from '../../project-files'
+import {
+  __resetLocalAgentRegistryForTests,
+  findAgentsDirectory,
+  getLoadedMCPServers,
+  initializeAgentRegistry,
+  loadAgentDefinitions,
+  loadLocalAgents,
+} from '../../utils/local-agent-registry'
+import {
+  activateProject,
+  shouldShowProjectPicker,
+} from '../../utils/project-picker'
 
 describe('cli/utils/project-picker', () => {
   test('returns true when start cwd is home directory', () => {
@@ -35,5 +53,153 @@ describe('cli/utils/project-picker', () => {
     const siblingDir = path.join(root, 'home', 'other-user')
 
     expect(shouldShowProjectPicker(siblingDir, homeDir)).toBe(false)
+  })
+
+  test('reloads local agents and MCP servers after selecting a project', async () => {
+    const originalCwd = process.cwd()
+    const originalProjectRoot = tryGetProjectRoot()
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'freebuff-project-'))
+    const launchDir = path.join(tempDir, 'launch')
+    const launchAgentsDir = path.join(launchDir, '.agents')
+    const projectDir = path.join(tempDir, 'project')
+    const agentsDir = path.join(projectDir, '.agents')
+
+    mkdirSync(launchAgentsDir, { recursive: true })
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      path.join(launchAgentsDir, 'launch-agent.ts'),
+      `export default {
+        id: 'launch-project-agent',
+        displayName: 'Launch Project Agent',
+        model: 'anthropic/claude-sonnet-4',
+        instructions: 'Loaded from the launch project'
+      }`,
+    )
+    writeFileSync(
+      path.join(agentsDir, 'selected-agent.ts'),
+      `export default {
+        id: 'selected-project-agent',
+        displayName: 'Selected Project Agent',
+        model: 'anthropic/claude-sonnet-4',
+        instructions: 'Loaded from the selected project'
+      }`,
+    )
+    writeFileSync(
+      path.join(agentsDir, 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          projectPickerServer: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      }),
+    )
+
+    try {
+      process.chdir(launchDir)
+      setProjectRoot(launchDir)
+      __resetLocalAgentRegistryForTests()
+      await initializeAgentRegistry()
+
+      expect(findAgentsDirectory()).toBe(launchAgentsDir)
+      expect(
+        loadLocalAgents().find((agent) => agent.id === 'launch-project-agent'),
+      ).toBeDefined()
+      expect(getLoadedMCPServers().projectPickerServer).toBeUndefined()
+
+      await activateProject(projectDir)
+
+      expect(process.cwd()).toBe(projectDir)
+      expect(getProjectRoot()).toBe(projectDir)
+      expect(findAgentsDirectory()).toBe(agentsDir)
+      const localAgents = loadLocalAgents()
+      expect(
+        localAgents.find((agent) => agent.id === 'launch-project-agent'),
+      ).toBeUndefined()
+      expect(
+        localAgents.find((agent) => agent.id === 'selected-project-agent'),
+      ).toBeDefined()
+      expect(getLoadedMCPServers().projectPickerServer).toMatchObject({
+        command: 'node',
+        args: ['server.js'],
+      })
+
+      const baseAgent = loadAgentDefinitions().find((definition) =>
+        definition.id.startsWith('base'),
+      )
+      expect(baseAgent).toBeDefined()
+      expect(baseAgent?.mcpServers?.projectPickerServer).toMatchObject({
+        command: 'node',
+        args: ['server.js'],
+      })
+    } finally {
+      process.chdir(originalCwd)
+      setProjectRoot(originalProjectRoot ?? originalCwd)
+      __resetLocalAgentRegistryForTests()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves the registry alone when reloadAgentRegistry is false', async () => {
+    const originalCwd = process.cwd()
+    const originalProjectRoot = tryGetProjectRoot()
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'freebuff-override-'))
+    const launchDir = path.join(tempDir, 'launch')
+    const launchAgentsDir = path.join(launchDir, '.agents')
+    const projectDir = path.join(tempDir, 'project')
+    const agentsDir = path.join(projectDir, '.agents')
+
+    mkdirSync(launchAgentsDir, { recursive: true })
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      path.join(launchAgentsDir, 'launch-agent.ts'),
+      `export default {
+        id: 'override-launch-agent',
+        displayName: 'Override Launch Agent',
+        model: 'anthropic/claude-sonnet-4',
+        instructions: 'Loaded from the launch project'
+      }`,
+    )
+    writeFileSync(
+      path.join(agentsDir, 'selected-agent.ts'),
+      `export default {
+        id: 'override-selected-agent',
+        displayName: 'Override Selected Agent',
+        model: 'anthropic/claude-sonnet-4',
+        instructions: 'Loaded from the selected project'
+      }`,
+    )
+
+    try {
+      process.chdir(launchDir)
+      setProjectRoot(launchDir)
+      __resetLocalAgentRegistryForTests()
+      await initializeAgentRegistry()
+
+      expect(
+        loadLocalAgents().find((agent) => agent.id === 'override-launch-agent'),
+      ).toBeDefined()
+
+      await activateProject(projectDir, { reloadAgentRegistry: false })
+
+      // The move still happens, only the registry is left as the caller found it,
+      // which is what an --agent override relies on
+      expect(process.cwd()).toBe(projectDir)
+      expect(getProjectRoot()).toBe(projectDir)
+
+      const localAgents = loadLocalAgents()
+      expect(
+        localAgents.find((agent) => agent.id === 'override-launch-agent'),
+      ).toBeDefined()
+      expect(
+        localAgents.find((agent) => agent.id === 'override-selected-agent'),
+      ).toBeUndefined()
+    } finally {
+      process.chdir(originalCwd)
+      setProjectRoot(originalProjectRoot ?? originalCwd)
+      __resetLocalAgentRegistryForTests()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 })

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -28,17 +28,19 @@ import { loadPackageVersion, parseArgs } from './cli-args'
 import { handlePublish } from './commands/publish'
 import { runPlainLogin } from './login/plain-login'
 import { initializeApp } from './init/init-app'
-import { getProjectRoot, setProjectRoot } from './project-files'
+import { getProjectRoot } from './project-files'
 import { trackEvent } from './utils/analytics'
 import { getAuthToken, getAuthTokenDetails } from './utils/auth'
-import { resetCodebuffClient } from './utils/codebuff-client'
 import { setApiClientAuthToken } from './utils/codebuff-api'
 import { IS_FREEBUFF } from './utils/constants'
 import { initializeAgentRegistry } from './utils/local-agent-registry'
 import { trimOversizedChatLogs } from './utils/chat-history'
 import { clearLogFile, logger } from './utils/logger'
 import { drainClientLogs } from './utils/log-shipper'
-import { shouldShowProjectPicker } from './utils/project-picker'
+import {
+  activateProject,
+  shouldShowProjectPicker,
+} from './utils/project-picker'
 import { saveRecentProject } from './utils/recent-projects'
 import { startEngagementTracking } from './utils/engagement'
 import {
@@ -343,8 +345,9 @@ async function main(): Promise<void> {
     // Callback for when user selects a new project from the picker
     const handleProjectChange = React.useCallback(
       async (newProjectPath: string) => {
-        // Change process working directory
-        process.chdir(newProjectPath)
+        await activateProject(newProjectPath, {
+          reloadAgentRegistry: !hasAgentOverride,
+        })
 
         // Track directory change (avoid logging full paths for privacy)
         const isGitRepo = fs.existsSync(path.join(newProjectPath, '.git'))
@@ -354,10 +357,6 @@ async function main(): Promise<void> {
           pathDepth,
           isHomeDir: newProjectPath === os.homedir(),
         })
-        // Update the project root in the module state
-        setProjectRoot(newProjectPath)
-        // Reset client to ensure tools use the updated project root
-        resetCodebuffClient()
         // Save to recent projects list
         saveRecentProject(newProjectPath)
         // Update local state
@@ -367,7 +366,7 @@ async function main(): Promise<void> {
         // Hide the picker and show the chat
         setShowProjectPickerScreen(false)
       },
-      [],
+      [hasAgentOverride],
     )
 
     return (

--- a/cli/src/utils/local-agent-registry.ts
+++ b/cli/src/utils/local-agent-registry.ts
@@ -90,6 +90,19 @@ export async function initializeAgentRegistry(): Promise<void> {
 }
 
 /**
+ * Reload the local agent registry after the active project changes.
+ *
+ * The derived agent-list and directory caches depend on the current working
+ * directory, so they must be cleared before the registry is initialized for
+ * the new project.
+ */
+export async function reloadLocalAgentRegistry(): Promise<void> {
+  cachedAgentsByMode.clear()
+  cachedAgentsDir = null
+  await initializeAgentRegistry()
+}
+
+/**
  * Get default agent directories to scan.
  * Matches the SDK's getDefaultAgentDirs() to ensure consistency.
  */

--- a/cli/src/utils/project-picker.ts
+++ b/cli/src/utils/project-picker.ts
@@ -1,5 +1,27 @@
 import path from 'path'
 
+import { setProjectRoot } from '../project-files'
+import { resetCodebuffClient } from './codebuff-client'
+import { reloadLocalAgentRegistry } from './local-agent-registry'
+
+interface ActivateProjectOptions {
+  reloadAgentRegistry?: boolean
+}
+
+export async function activateProject(
+  projectPath: string,
+  { reloadAgentRegistry = true }: ActivateProjectOptions = {},
+): Promise<void> {
+  process.chdir(projectPath)
+  setProjectRoot(projectPath)
+
+  if (reloadAgentRegistry) {
+    await reloadLocalAgentRegistry()
+  }
+
+  resetCodebuffClient()
+}
+
 export function shouldShowProjectPicker(
   startCwd: string,
   homeDir: string,


### PR DESCRIPTION
Recreated from #966, which GitHub auto-closed when this repository's history was rewritten. Same change, rebased onto the new `main` at `d4902003`. Fixes #957.

Picking a different project through the project picker changes the working directory, moves the project root and resets the client, but never re-scans `.agents/` for the new directory. `cachedAgentsDir` and `cachedAgentsByMode` in `local-agent-registry.ts` go on serving the launch directory, so the selected project's MCP servers and local agents never reach the base agent definition.

`handleProjectChange` in `cli/src/index.tsx` had the chdir, `setProjectRoot` and `resetCodebuffClient` inline. This moves that sequence into `activateProject()` in `project-picker.ts` and puts the registry reload in the middle of it, so the ordering lives in one place instead of being duplicated at the call site.

`reloadLocalAgentRegistry()` clears only `cachedAgentsDir` and `cachedAgentsByMode`, and that is deliberate. The module keeps five mutable caches. The other three, `userAgentsCache`, `userAgentFilePaths` and `mcpServersCache`, are reassigned by `initializeAgentRegistry()` on both its success and failure paths, `mcpServersCache` from `loadMCPConfigSync()`, which reads the cwd. So `getLoadedMCPServers()` is covered as long as the chdir happens first. The two derived ones are the only ones nothing else resets.

The test writes real `.agents/*.ts` and `mcp.json` files into temporary launch and project directories, warms the caches in the launch project, switches through `activateProject()`, then asserts the selected project supplies the agent directory, the local agent list, the MCP server and the base agent definition, with the launch project's agent gone. A second case covers the `{ reloadAgentRegistry: false }` skip path, where the chdir and project root still move but the launch project's agent is still the one served. I checked that case earns its place by making `activateProject` reload unconditionally: it is the only test that then fails.

Validation on this head:

```
bun test cli/src/__tests__/utils/     23 pass, 0 fail
cd cli && bun run typecheck           23 errors
```

The same command on the base, `d4902003`, also gives 23, so this change adds none. That command reaches past `cli`: 7 of them come from `../sdk/src/impl/llm.ts`, 6 from `../common/src/util/messages.ts`, and 10 from under `cli/src`. Of those 10, nine are `react-dom/server` declarations in component tests and the tenth is `wrapper-safety.test.ts:265`, a `tar` module that does not resolve. None of the four files this PR touches appears in the list.

An earlier revision of this description said 10 errors, all `react-dom/server`. That counted only the `cli` subset. Corrected here.

