### PR TITLE
docs(cli): document account switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Then describe what you want. Freebuff finds the relevant files, makes changes, a
 ### Switch accounts
 
 To change the account used by the CLI, enter `/logout` (or `/signout`) in an
-active session. After logging out, press Enter on the login screen, or run
-`freebuff login` from your shell to start the browser login flow again.
+active session. After logging out, press Enter on the login screen to sign in
+again in that interactive session. Alternatively, open a fresh shell/session
+and run `freebuff login` to start the browser login flow directly.
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ freebuff
 
 Then describe what you want. Freebuff finds the relevant files, makes changes, and runs the checks that matter for your project.
 
+### Switch accounts
+
+To change the account used by the CLI, enter `/logout` (or `/signout`) in an
+active session. After logging out, press Enter on the login screen, or run
+`freebuff login` from your shell to start the browser login flow again.
+
 ## Models
 
 Freebuff includes a curated model catalog. The regular picker currently offers:


### PR DESCRIPTION
> Recreated on the rewritten `main` after #1104 was auto-closed during repository maintenance. This carries the same reviewed change set on the new history.

## Summary

- document how to switch the account used by the CLI
- mention the existing `/logout` and `/signout` commands
- point users to the `freebuff login` browser flow after logout

Fixes #1086

## Validation

Prior validation before the history rewrite:

- verified `command-registry.ts` defines `/logout` with `/signout` as an alias
- verified `login-modal.tsx` prompts `Press ENTER to login...` before starting the browser login flow
- verified `cli-args.ts` accepts `freebuff login`
- `git diff --check` passed