### PR TITLE
fix(cli): disable Freebuff chat logo sheen

### DIFF
--- a/cli/src/components/chat-header.tsx
+++ b/cli/src/components/chat-header.tsx
@@ -8,6 +8,7 @@ import { IS_FREEBUFF } from '../utils/constants'
 import { openFileAtPath } from '../utils/open-file'
 import { formatCwd } from '../utils/path-helpers'
 import { getLogoAccentColor, getLogoBlockColor } from '../utils/theme-system'
+import { shouldAnimateChatHeader } from '../utils/chat-header-animation'
 import { TerminalLink } from './terminal-link'
 
 export const ChatHeader = memo(function ChatHeader({
@@ -23,7 +24,7 @@ export const ChatHeader = memo(function ChatHeader({
   const blockColor = getLogoBlockColor(theme.name)
   const accentColor = getLogoAccentColor(theme.name)
   const { applySheenToChar } = useSheenAnimation({
-    enabled: animationEnabled,
+    enabled: shouldAnimateChatHeader(animationEnabled, IS_FREEBUFF),
     logoColor: theme.foreground,
     accentColor,
     blockColor,

--- a/cli/src/utils/__tests__/chat-header-animation.test.ts
+++ b/cli/src/utils/__tests__/chat-header-animation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+
+import { shouldAnimateChatHeader } from '../chat-header-animation'
+
+describe('shouldAnimateChatHeader', () => {
+  it('disables the sheen for the Freebuff chat header', () => {
+    expect(shouldAnimateChatHeader(true, true)).toBe(false)
+  })
+
+  it('keeps the Codebuff sheen when the header is active', () => {
+    expect(shouldAnimateChatHeader(true, false)).toBe(true)
+  })
+
+  it('does not animate an inactive header for either product', () => {
+    expect(shouldAnimateChatHeader(false, true)).toBe(false)
+    expect(shouldAnimateChatHeader(false, false)).toBe(false)
+  })
+})

--- a/cli/src/utils/chat-header-animation.ts
+++ b/cli/src/utils/chat-header-animation.ts
@@ -1,6 +1,6 @@
 /**
- * Freebuff's chat logo sheen can make the focused input appear to flicker.
- * Keep the animation for Codebuff while leaving the Freebuff chat header static.
+ * Freebuff intentionally keeps the chat-header logo static.
+ * Keep the existing sheen for Codebuff while honoring the global animation gate.
  */
 export function shouldAnimateChatHeader(
   animationEnabled: boolean,

--- a/cli/src/utils/chat-header-animation.ts
+++ b/cli/src/utils/chat-header-animation.ts
@@ -1,0 +1,10 @@
+/**
+ * Freebuff's chat logo sheen can make the focused input appear to flicker.
+ * Keep the animation for Codebuff while leaving the Freebuff chat header static.
+ */
+export function shouldAnimateChatHeader(
+  animationEnabled: boolean,
+  isFreebuff: boolean,
+): boolean {
+  return animationEnabled && !isFreebuff
+}


### PR DESCRIPTION
> Recreated on the rewritten `main` after #1102 was auto-closed during repository maintenance. This carries the same reviewed change set on the new history.

## Summary
- disable the animated chat-header logo sheen in Freebuff builds
- keep the existing animation for standard Codebuff builds
- add focused regression coverage for both product paths

Fixes #1035

## Validation
Prior validation before the history rewrite:
- focused animation tests: 3 passed
- related queue tests: 4 passed
- full CLI suite: 2,367 passed, 9 skipped; existing checkout/environment failures remain (34 failed tests and 32 harness errors)
- CLI typecheck: existing missing `tar` and `react-dom/server` declarations; no errors from changed files
- Prettier check for changed files: passed
- `git diff --check`: passed