### PR TITLE
fix(cli): survive unavailable chat log directory

### DIFF
--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import path from 'path'
+
+import { CHAT_LOG_FILENAME, resolveLogTarget } from '../logger'
+
+describe('resolveLogTarget', () => {
+  test('uses the project debug log in development', () => {
+    let currentChatDirCalls = 0
+
+    const target = resolveLogTarget({
+      projectRoot: '/project',
+      isDev: true,
+      getCurrentChatDir: () => {
+        currentChatDirCalls += 1
+        return '/chat'
+      },
+    })
+
+    expect(target).toBe(path.join('/project', 'debug', 'cli.jsonl'))
+    expect(currentChatDirCalls).toBe(0)
+  })
+
+  test('uses the current chat log in production', () => {
+    const target = resolveLogTarget({
+      projectRoot: '/project',
+      isDev: false,
+      getCurrentChatDir: () => '/chat/2026-01-01T00-00-00.000Z',
+    })
+
+    expect(target).toBe(
+      path.join('/chat/2026-01-01T00-00-00.000Z', CHAT_LOG_FILENAME),
+    )
+  })
+
+  test('skips file logging when the chat directory cannot be created', () => {
+    const target = resolveLogTarget({
+      projectRoot: '/project',
+      isDev: false,
+      getCurrentChatDir: () => {
+        throw new Error('EACCES')
+      },
+    })
+
+    expect(target).toBeUndefined()
+  })
+})

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -100,6 +100,45 @@ function setLogPath(p: string): void {
   )
 }
 
+/**
+ * Resolve the per-run log destination without allowing filesystem failures to
+ * take down the CLI during startup.
+ *
+ * In production, resolving the destination creates the current chat
+ * directory. That directory may be unavailable (for example, when the
+ * config directory is read-only), so callers must treat an absent destination
+ * as "continue without file logging".
+ */
+export function resolveLogTarget(params: {
+  projectRoot: string
+  isDev: boolean
+  getCurrentChatDir: () => string
+}): string | undefined {
+  try {
+    return params.isDev
+      ? path.join(params.projectRoot, 'debug', 'cli.jsonl')
+      : path.join(params.getCurrentChatDir(), CHAT_LOG_FILENAME)
+  } catch {
+    return undefined
+  }
+}
+
+function trySetLogPath(projectRoot: string): void {
+  const logTarget = resolveLogTarget({
+    projectRoot,
+    isDev: IS_DEV,
+    getCurrentChatDir,
+  })
+  if (!logTarget) return
+
+  try {
+    setLogPath(logTarget)
+  } catch {
+    // File logging is best-effort and must never prevent the CLI from
+    // starting when the config or chat directory cannot be written.
+  }
+}
+
 export function clearLogFile(): void {
   const projectRoot = getProjectRoot()
   const debugDir = path.join(projectRoot, 'debug')
@@ -139,12 +178,7 @@ function sendAnalyticsAndLog(
       projectRoot = undefined
     }
     if (projectRoot) {
-      const logTarget =
-        IS_DEV
-          ? path.join(projectRoot, 'debug', 'cli.jsonl')
-          : path.join(getCurrentChatDir(), CHAT_LOG_FILENAME)
-
-      setLogPath(logTarget)
+      trySetLogPath(projectRoot)
     }
   }
 

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -135,7 +135,8 @@ function trySetLogPath(projectRoot: string): void {
     setLogPath(logTarget)
   } catch {
     // File logging is best-effort and must never prevent the CLI from
-    // starting when the config or chat directory cannot be written.
+    // starting when the config or chat directory cannot be written. Keep this
+    // silent: writing to stderr during startup can corrupt the interactive UI.
   }
 }
 


### PR DESCRIPTION
> Recreated on the rewritten `main` after #1099 was auto-closed during repository maintenance. This carries the same reviewed change set on the new history.

## Summary

- prevent logger initialization from crashing the CLI when the current chat directory cannot be created
- keep file logging best-effort while preserving the existing development and production destinations
- add regression coverage for both destinations and the unavailable-chat-directory path

Fixes #783

## Validation

Prior validation before the history rewrite:

- `logger.test.ts`: 3 passed
- common typecheck: passed
- SDK typecheck: passed
- `git diff --check`: passed
- full CLI test command: 2,111 passed; existing checkout/environment failures remain in unrelated Infisical, read-only config, and missing release-dependency tests