### PR TITLE
feat(cli): add a non-interrupting /btw command

### DIFF
--- a/cli/src/commands/__tests__/btw-attachments.test.ts
+++ b/cli/src/commands/__tests__/btw-attachments.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import { COMMAND_REGISTRY } from '../command-registry'
+import { useChatStore } from '../../state/chat-store'
+
+import type { RouterParams } from '../command-registry'
+
+function createMockParams(
+  overrides: Partial<RouterParams> = {},
+): RouterParams {
+  return {
+    agentMode: 'DEFAULT',
+    inputRef: { current: null },
+    inputValue: '/btw check the parser',
+    isChainInProgressRef: { current: false },
+    isStreaming: false,
+    logoutMutation: {} as RouterParams['logoutMutation'],
+    streamMessageIdRef: { current: null },
+    addToQueue: mock(() => {}),
+    clearMessages: mock(() => {}),
+    saveToHistory: mock(() => {}),
+    scrollToLatest: mock(() => {}),
+    sendMessage: mock(async () => {}),
+    setCanProcessQueue: mock(() => {}),
+    setInputFocused: mock(() => {}),
+    setInputValue: mock(() => {}),
+    setIsAuthenticated: mock(() => {}),
+    setMessages: mock(() => {}),
+    setUser: mock(() => {}),
+    ...overrides,
+  }
+}
+
+describe('/btw attachment routing', () => {
+  afterEach(() => {
+    useChatStore.getState().clearPendingAttachments()
+  })
+
+  test('leaves idle attachments staged for sendMessage to consume', () => {
+    const btwCmd = COMMAND_REGISTRY.find((command) => command.name === 'btw')
+    expect(btwCmd).toBeDefined()
+
+    const attachment = {
+      kind: 'text' as const,
+      id: 'note.txt',
+      content: 'remember the edge case',
+      preview: 'remember the edge case',
+      charCount: 22,
+    }
+    useChatStore.getState().addPendingAttachment(attachment)
+
+    const sendMessage = mock(async () => {})
+    btwCmd!.handler(createMockParams({ sendMessage }), 'check the parser')
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    // sendMessage intentionally receives no explicit `attachments` value here:
+    // prepareUserMessage falls back to useChatStore.pendingAttachments and clears
+    // that store only after it has captured the attachments for the direct send.
+    expect(sendMessage).toHaveBeenCalledWith({
+      content: expect.stringContaining('check the parser'),
+      agentMode: 'DEFAULT',
+    })
+    expect(useChatStore.getState().pendingAttachments).toEqual([attachment])
+  })
+})

--- a/cli/src/commands/__tests__/command-args.test.ts
+++ b/cli/src/commands/__tests__/command-args.test.ts
@@ -371,10 +371,14 @@ describe('command factory pattern', () => {
       const addToQueue = mock(() => {})
       const sendMessage = mock(async () => {})
       const setInputFocused = mock(() => {})
+      const saveToHistory = mock(() => {})
+      const focus = mock(() => {})
       const params = createMockParams({
+        inputRef: { current: { focus } } as RouterParams['inputRef'],
         inputValue: '/btw remember the edge case',
         isStreaming: true,
         addToQueue,
+        saveToHistory,
         sendMessage,
         setInputFocused,
       })
@@ -386,7 +390,9 @@ describe('command factory pattern', () => {
         [attachment],
       )
       expect(sendMessage).not.toHaveBeenCalled()
+      expect(saveToHistory).toHaveBeenCalledWith('/btw remember the edge case')
       expect(setInputFocused).toHaveBeenCalledWith(true)
+      expect(focus).toHaveBeenCalledTimes(1)
       expect(useChatStore.getState().pendingAttachments).toEqual([])
     })
 

--- a/cli/src/commands/__tests__/command-args.test.ts
+++ b/cli/src/commands/__tests__/command-args.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect, mock } from 'bun:test'
+import { afterEach, describe, test, expect, mock } from 'bun:test'
 
 import { useFeedbackStore } from '../../state/feedback-store'
+import { useChatStore } from '../../state/chat-store'
 import {
   registerActiveRun,
   stopActiveRun,
@@ -178,6 +179,7 @@ describe('command factory pattern', () => {
       // mode:* commands also accept args now
       const expectedWithArgs = [
         'feedback',
+        'btw',
         'bash',
         'image',
         'publish',
@@ -344,6 +346,87 @@ describe('command factory pattern', () => {
 
       // Should still return openFeedbackMode
       expect(result).toEqual({ openFeedbackMode: true })
+    })
+  })
+
+  describe('/btw command', () => {
+    afterEach(() => {
+      useChatStore.getState().clearPendingAttachments()
+    })
+
+    test('queues the note and pending attachments while a turn is active', () => {
+      const btwCmd = COMMAND_REGISTRY.find((c) => c.name === 'btw')
+      expect(btwCmd).toBeDefined()
+
+      const attachment = {
+        kind: 'text' as const,
+        id: 'note.txt',
+        content: 'remember the edge case',
+        preview: 'remember the edge case',
+        charCount: 22,
+      }
+      useChatStore.getState().clearPendingAttachments()
+      useChatStore.getState().addPendingAttachment(attachment)
+
+      const addToQueue = mock(() => {})
+      const sendMessage = mock(async () => {})
+      const setInputFocused = mock(() => {})
+      const params = createMockParams({
+        inputValue: '/btw remember the edge case',
+        isStreaming: true,
+        addToQueue,
+        sendMessage,
+        setInputFocused,
+      })
+
+      btwCmd!.handler(params, 'remember the edge case')
+
+      expect(addToQueue).toHaveBeenCalledWith(
+        expect.stringContaining('remember the edge case'),
+        [attachment],
+      )
+      expect(sendMessage).not.toHaveBeenCalled()
+      expect(setInputFocused).toHaveBeenCalledWith(true)
+      expect(useChatStore.getState().pendingAttachments).toEqual([])
+    })
+
+    test('sends the note immediately when the CLI is idle', () => {
+      const btwCmd = COMMAND_REGISTRY.find((c) => c.name === 'btw')
+      expect(btwCmd).toBeDefined()
+
+      const addToQueue = mock(() => {})
+      const sendMessage = mock(async () => {})
+      const params = createMockParams({
+        inputValue: '/btw check the parser',
+        addToQueue,
+        sendMessage,
+      })
+
+      btwCmd!.handler(params, 'check the parser')
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        content: expect.stringContaining('check the parser'),
+        agentMode: 'DEFAULT',
+      })
+      expect(addToQueue).not.toHaveBeenCalled()
+    })
+
+    test('shows usage instead of sending an empty note', () => {
+      const btwCmd = COMMAND_REGISTRY.find((c) => c.name === 'btw')
+      expect(btwCmd).toBeDefined()
+
+      const setMessages = mock(() => {})
+      const sendMessage = mock(async () => {})
+      const params = createMockParams({
+        inputValue: '/btw',
+        setMessages,
+        sendMessage,
+      })
+
+      btwCmd!.handler(params, '')
+
+      expect(setMessages).toHaveBeenCalled()
+      expect(sendMessage).not.toHaveBeenCalled()
     })
   })
 })

--- a/cli/src/commands/__tests__/prompt-builders.test.ts
+++ b/cli/src/commands/__tests__/prompt-builders.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  buildBtwPrompt,
   buildPlanPrompt,
   buildReviewPrompt,
   buildReviewPromptFromArgs,
 } from '../prompt-builders'
 
 describe('prompt-builders base prompts', () => {
+  test('/btw keeps the note and removes command whitespace', () => {
+    expect(buildBtwPrompt('  remember to run tests  ')).toBe(
+      'The user has an additional thought for the current task. Consider it without abandoning the original request:\n\nremember to run tests',
+    )
+  })
+
   // These used to branch on whether the user had connected a ChatGPT account,
   // delegating the deep-thinking step to @thinker-gpt if so. That integration
   // is gone, so there is one branch: the user's selected model does the work.

--- a/cli/src/commands/command-registry.ts
+++ b/cli/src/commands/command-registry.ts
@@ -10,7 +10,13 @@ import {
   collectProcessDiagnostics,
   formatProcessDiagnostics,
 } from './process-diagnostics'
-import { buildInterviewPrompt, buildPlanPrompt, buildReviewPromptFromArgs, buildSkillPrompt } from './prompt-builders'
+import {
+  buildBtwPrompt,
+  buildInterviewPrompt,
+  buildPlanPrompt,
+  buildReviewPromptFromArgs,
+  buildSkillPrompt,
+} from './prompt-builders'
 import { handleReasoningCommand } from './reasoning'
 import { runBashCommand } from './router'
 import { handleUsageCommand } from './usage'
@@ -607,6 +613,46 @@ const ALL_COMMANDS: CommandDefinition[] = [
 
       // Otherwise open the selection UI
       return { openReviewScreen: true }
+    },
+  }),
+  defineCommandWithArgs({
+    name: 'btw',
+    handler: (params, args) => {
+      const trimmedArgs = args.trim()
+      const rawInput = params.inputValue.trim()
+
+      params.saveToHistory(rawInput)
+      clearInput(params)
+
+      if (!trimmedArgs) {
+        params.setMessages((prev) => [
+          ...prev,
+          getSystemMessage('Usage: /btw <additional thought>'),
+        ])
+        return
+      }
+
+      const btwPrompt = buildBtwPrompt(trimmedArgs)
+      const isBusy =
+        params.isStreaming ||
+        params.streamMessageIdRef.current ||
+        params.isChainInProgressRef.current
+
+      if (isBusy) {
+        const pendingAttachments = capturePendingAttachments()
+        params.addToQueue(btwPrompt, pendingAttachments)
+        params.setInputFocused(true)
+        params.inputRef.current?.focus()
+        return
+      }
+
+      params.sendMessage({
+        content: btwPrompt,
+        agentMode: params.agentMode,
+      })
+      setTimeout(() => {
+        params.scrollToLatest()
+      }, 0)
     },
   }),
   defineCommand({

--- a/cli/src/commands/prompt-builders.ts
+++ b/cli/src/commands/prompt-builders.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized prompt builders for /plan and /review commands.
+ * Centralized prompt builders for /plan, /review, and /btw commands.
  * This ensures consistent behavior regardless of entry path. Both run on the
  * user's currently selected model.
  */
@@ -9,6 +9,17 @@ const PLAN_BASE_PROMPT =
   'Gather all the relevant context and then think carefully about how to implement the following:'
 const REVIEW_BASE_PROMPT =
   'Please gather all relevant context and then carefully review:'
+
+const BTW_BASE_PROMPT =
+  'The user has an additional thought for the current task. Consider it without abandoning the original request:'
+
+/** Build the prompt sent by `/btw` without the command syntax. */
+export function buildBtwPrompt(input: string): string {
+  const trimmedInput = input.trim()
+  return trimmedInput
+    ? `${BTW_BASE_PROMPT}\n\n${trimmedInput}`
+    : BTW_BASE_PROMPT
+}
 
 /**
  * Build a plan prompt from user input.
@@ -117,4 +128,3 @@ export function buildReviewPromptFromArgs(input: string): string {
   // Use the same format as preset scopes for consistency
   return `${REVIEW_BASE_PROMPT} ${trimmedInput}`
 }
-

--- a/cli/src/data/slash-commands.ts
+++ b/cli/src/data/slash-commands.ts
@@ -116,6 +116,12 @@ const ALL_SLASH_COMMANDS: SlashCommand[] = [
     description: 'Review code changes',
   },
   {
+    id: 'btw',
+    label: 'btw',
+    description:
+      'Queue an additional thought without interrupting the current task',
+  },
+  {
     id: 'queue',
     label: 'queue',
     description: 'Edit, reorder, or delete the messages waiting to be sent',


### PR DESCRIPTION
> Recreated on the rewritten `main` after #1103 was auto-closed during repository maintenance. This carries the final reviewed branch state onto the new history while preserving upstream changes added after the rewrite.

## Summary

- add `/btw <additional thought>` to send context without interrupting an active turn
- reuse the existing queue while preserving pending attachments
- send directly when idle and show usage for an empty note
- add slash-command metadata and regression tests
- retain the focused idle-attachment handoff regression added after review on the original PR

Fixes #1052

## Validation

Prior validation before the history rewrite:

- targeted prompt, command, and router tests: 81 passed
- full CLI suite: 2,368 passed, 9 skipped
- full suite still reports 34 existing release-wrapper failures and 32 environment/harness errors
- CLI typecheck reaches existing missing `tar` and `react-dom/server` declarations; no errors point to the changed files
- `git diff --check` passed

The port onto rewritten `main` was three-way applied. Five files applied cleanly; the only drifted file was `command-registry.ts`, where the `/btw` hunk was reapplied while preserving the new upstream `buildSkillPrompt` import.