### PR TITLE
Explain why read_files blocks gitignored files

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -183,7 +183,9 @@ terminal-command or internal-edit restrictions.
 Ignore-rule blocks on `read_files` return `[BLOCKED]` followed by a trailing
 reason. `.codebuffignore` — a project-level ignore file with `.gitignore`
 syntax, checked alongside `.gitignore` — is the escape hatch: adjust or
-negate the matching rule there to allow tool reads of a specific file.
+negate the matching rule there to allow tool reads of a specific file (a
+file-level negation cannot re-include a path whose parent directory is itself
+excluded).
 
 Custom `overrideTools.read_files` implementations must preserve project
 gitignore behavior for env templates. The built-in CLI, Desktop, Web, and Cloud

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -180,6 +180,11 @@ gitignore. This built-in policy is scoped to
 SDK-mediated agent file reads (including `read_files`); it does not add
 terminal-command or internal-edit restrictions.
 
+Ignore-rule blocks on `read_files` return `[BLOCKED]` followed by a trailing
+reason. `.codebuffignore` — a project-level ignore file with `.gitignore`
+syntax, checked alongside `.gitignore` — is the escape hatch: adjust or
+negate the matching rule there to allow tool reads of a specific file.
+
 Custom `overrideTools.read_files` implementations must preserve project
 gitignore behavior for env templates. The built-in CLI, Desktop, Web, and Cloud
 bridges already do this.

--- a/sdk/src/__tests__/read-files.test.ts
+++ b/sdk/src/__tests__/read-files.test.ts
@@ -436,6 +436,19 @@ describe('getFiles', () => {
       ).toBe(true)
       expect(goneResult['AGENTS.local.md']).not.toContain('exists on disk')
 
+      // Internal-edit path (no env policy): a secret blocked by built-in
+      // ignore defaults must stay opaque too.
+      const editFs = createMockFs({
+        files: { '/project/.env': { content: 'SECRET=value' } },
+      })
+      const editResult = await getFiles({
+        filePaths: ['.env'],
+        cwd: '/project',
+        fs: editFs,
+        enforceEnvPolicy: false,
+      })
+      expect(editResult['.env']).toBe(FILE_READ_STATUS.IGNORED)
+
       // The env-policy block must NOT leak a reason or an unblock hint.
       const envFs = createMockFs({
         files: { '/project/.env': { content: 'SECRET=value' } },

--- a/sdk/src/__tests__/read-files.test.ts
+++ b/sdk/src/__tests__/read-files.test.ts
@@ -393,9 +393,59 @@ describe('getFiles', () => {
         fs: mockFs,
       })
 
-      expect(result['node_modules/package/index.js']).toBe(
-        FILE_READ_STATUS.IGNORED,
+      expect(
+        result['node_modules/package/index.js']!.startsWith(
+          FILE_READ_STATUS.IGNORED,
+        ),
+      ).toBe(true)
+      expect(result['node_modules/package/index.js']).toContain(
+        'excluded by ignore rules',
       )
+    })
+
+    test('ignore-rule block explains reason and unblock path; env-policy block stays opaque', async () => {
+      isFileIgnoredSpy.mockResolvedValue(true)
+
+      const mockFs = createMockFs({
+        files: {
+          '/project/AGENTS.local.md': { content: 'private notes' },
+        },
+      })
+
+      const result = await getFiles({
+        filePaths: ['AGENTS.local.md'],
+        cwd: '/project',
+        fs: mockFs,
+      })
+
+      expect(
+        result['AGENTS.local.md']!.startsWith(FILE_READ_STATUS.IGNORED),
+      ).toBe(true)
+      expect(result['AGENTS.local.md']).toContain('excluded by ignore rules')
+      expect(result['AGENTS.local.md']).toContain('cannot re-include')
+
+      // Ignored-and-deleted: the block must not assert the file exists.
+      const goneFs = createMockFs({ files: {} })
+      const goneResult = await getFiles({
+        filePaths: ['AGENTS.local.md'],
+        cwd: '/project',
+        fs: goneFs,
+      })
+      expect(
+        goneResult['AGENTS.local.md']!.startsWith(FILE_READ_STATUS.IGNORED),
+      ).toBe(true)
+      expect(goneResult['AGENTS.local.md']).not.toContain('exists on disk')
+
+      // The env-policy block must NOT leak a reason or an unblock hint.
+      const envFs = createMockFs({
+        files: { '/project/.env': { content: 'SECRET=value' } },
+      })
+      const envResult = await getFiles({
+        filePaths: ['.env'],
+        cwd: '/project',
+        fs: envFs,
+      })
+      expect(envResult['.env']).toBe(FILE_READ_STATUS.IGNORED)
     })
 
     test('should call isFileIgnored with correct parameters', async () => {
@@ -436,7 +486,11 @@ describe('getFiles', () => {
       })
 
       expect(result['src/index.ts']).toBe('main code')
-      expect(result['node_modules/pkg/index.js']).toBe(FILE_READ_STATUS.IGNORED)
+      expect(
+        result['node_modules/pkg/index.js']!.startsWith(
+          FILE_READ_STATUS.IGNORED,
+        ),
+      ).toBe(true)
     })
   })
 
@@ -454,10 +508,13 @@ describe('getFiles', () => {
         filePaths: ['node_modules/pkg/index.js'],
         cwd: '/project',
         fs: mockFs,
-        // No fileFilter provided - SDK applies default gitignore checking
       })
 
-      expect(result['node_modules/pkg/index.js']).toBe(FILE_READ_STATUS.IGNORED)
+      expect(
+        result['node_modules/pkg/index.js']!.startsWith(
+          FILE_READ_STATUS.IGNORED,
+        ),
+      ).toBe(true)
       expect(isFileIgnoredSpy).toHaveBeenCalled()
     })
 
@@ -615,8 +672,12 @@ describe('getFiles', () => {
         fileFilter: () => ({ status: 'allow' }),
       })
 
-      expect(result['.env.example']).toBe(FILE_READ_STATUS.IGNORED)
-      expect(result['.ENV.SAMPLE']).toBe(FILE_READ_STATUS.IGNORED)
+      expect(result['.env.example']!.startsWith(FILE_READ_STATUS.IGNORED)).toBe(
+        true,
+      )
+      expect(result['.ENV.SAMPLE']!.startsWith(FILE_READ_STATUS.IGNORED)).toBe(
+        true,
+      )
       expect(isFileIgnoredSpy).toHaveBeenCalledTimes(2)
     })
 

--- a/sdk/src/__tests__/run-file-filter.test.ts
+++ b/sdk/src/__tests__/run-file-filter.test.ts
@@ -275,7 +275,9 @@ describe('CodebuffClientOptions fileFilter', () => {
     })
 
     expect(result.output.type).toBe('lastMessage')
-    expect(requestedFiles['.env.example']).toBe(FILE_READ_STATUS.IGNORED)
+    expect(
+      requestedFiles['.env.example']!.startsWith(FILE_READ_STATUS.IGNORED),
+    ).toBe(true)
   })
 
   it('should pass fileFilter to requestOptionalFile as well', async () => {

--- a/sdk/src/tools/read-files.ts
+++ b/sdk/src/tools/read-files.ts
@@ -99,7 +99,20 @@ export async function getFiles(params: {
         ...(isEnvTemplate ? { allowEnvTemplate: true } : {}),
       })
       if (ignored) {
-        result[relativePath] = FILE_READ_STATUS.IGNORED
+        // Keep the sentinel as the prefix (consumers match with startsWith)
+        // and append the reason, following the FILE_TOO_LARGE precedent.
+        // The ignore check never touches the file itself, so only claim
+        // existence when a stat confirms it.
+        let exists = false
+        try {
+          await fs.stat(fullPath)
+          exists = true
+        } catch {
+          // missing or unreadable: omit the existence claim
+        }
+        result[relativePath] =
+          FILE_READ_STATUS.IGNORED +
+          `: ${isEnvTemplate ? 'blocked by ignore-rule checking' : 'excluded by ignore rules'} (.gitignore, .codebuffignore, or built-in defaults), not an OS permission issue.${exists ? ' The file exists on disk;' : ''} glob and code_search omit it for the same reason. To allow tool reads, adjust or negate the matching rule in .codebuffignore (a file-level negation cannot re-include a path under an excluded directory).`
         continue
       }
     }

--- a/sdk/src/tools/read-files.ts
+++ b/sdk/src/tools/read-files.ts
@@ -99,6 +99,13 @@ export async function getFiles(params: {
         ...(isEnvTemplate ? { allowEnvTemplate: true } : {}),
       })
       if (ignored) {
+        // The internal-edit path (enforceEnvPolicy: false) skips the env
+        // gate above, so secrets can reach this branch via built-in ignore
+        // defaults. Never explain or hint unblocking for them.
+        if (isSensitiveEnvFilePath(relativePath)) {
+          result[relativePath] = FILE_READ_STATUS.IGNORED
+          continue
+        }
         // Keep the sentinel as the prefix (consumers match with startsWith)
         // and append the reason, following the FILE_TOO_LARGE precedent.
         // The ignore check never touches the file itself, so only claim


### PR DESCRIPTION
## Summary

`read_files` returns a bare `[BLOCKED]` when a file is excluded by ignore rules, with no reason and no remediation — the model can't tell the user why, and often can't even tell the file exists (glob/code_search omit it too). This makes the ignore-rule block self-describing, following the existing `FILE_TOO_LARGE` precedent of sentinel + trailing explanation. Addresses #1151 (the interactive permission prompt the reporter also asks for is host-app side; see Out of scope).

## Root cause

`sdk/src/tools/read-files.ts` returns `FILE_READ_STATUS.IGNORED` (`'[BLOCKED]'`) verbatim from three distinct block paths: the `.env` policy, a host `fileFilter`, and the gitignore/`.codebuffignore`/built-in-defaults check. Only the third is the silent, surprising one users hit — and it gave the model nothing to work with. The sentinel is consumed via `startsWith` (`HIDDEN_FILE_READ_STATUS` / `toOptionalFile` in `common/src/constants/paths.ts`) and rendered pass-through by `agent-runtime`, so a trailing explanation is safe; `TOO_LARGE` already ships one.

## Changes

1. `sdk/src/tools/read-files.ts` — in the `isFileIgnored` branch only, the result becomes `[BLOCKED]: <reason> <remediation>`:
   - Names the rule sources (`.gitignore`, `.codebuffignore`, built-in defaults) and states it is not an OS permission issue.
   - Claims the file exists on disk **only when a `fs.stat` confirms it** (the ignore check itself never touches the file, so an ignored-and-deleted path must not get the existence claim).
   - For the env-template sub-case, where `isFileIgnored` can fail closed on an unreadable ignore file without any rule matching (`common/src/project-file-tree.ts`, `throwOnReadError: allowEnvTemplate`), the wording hedges to "blocked by ignore-rule checking" instead of asserting a match.
   - Remediation says to adjust or negate the matching rule in `.codebuffignore`, with the explicit caveat that a file-level negation cannot re-include a path under an excluded directory (`isIgnoredByIgnoreChain` returns on the first ignored parent prefix, so `!build/out.js` is inert when `build/` itself is ignored).
   - The `.env`-policy and custom-`fileFilter` blocks stay bare `[BLOCKED]` — those are deliberate security/host decisions that shouldn't leak reasons.
2. `sdk/src/tools/read-files.ts` — the explanatory suffix is suppressed for sensitive env paths even on the internal-edit path (`enforceEnvPolicy: false`, which skips the top env gate), so a secret blocked via built-in ignore defaults still gets a bare `[BLOCKED]`.
3. `sdk/README.md` — documents that ignore-rule blocks carry a trailing reason and that `.codebuffignore` (`.gitignore` syntax, checked alongside) is the project-level escape hatch; previously undocumented repo-wide.
4. `sdk/src/__tests__/read-files.test.ts` — gitignore-path assertions switched from exact `toBe` to sentinel-prefix `startsWith` (env-policy/filter-block assertions remain exact, guarding the opacity); new regression test asserts the reason text, the directory-negation caveat, the omitted existence claim for an ignored-and-deleted file, and that the `.env` policy block stays opaque.
5. `sdk/src/__tests__/run-file-filter.test.ts` — one gitignore-path assertion switched to prefix match.

Out of scope: (a) an interactive permission prompt — no request-permission primitive exists in the public tree (contracts, client action, and the desktop UI are all private-side); this PR makes the tool layer say *why* so a host (or the model, in prose) can offer the `.codebuffignore` escape the reporter found manually. (b) changing glob/code_search output — separate surface, separate PR. The issue's "agent cannot detect the file exists" complaint is addressed here at the tool layer: the block message now states the file was omitted by discovery for the same reason, and that it exists on disk when a stat confirms it.

## Tests

- The two touched test files (`read-files.test.ts`, `run-file-filter.test.ts`): 44 pass / 0 fail.
- Regression proof: with the source change stashed, the new test fails (`ignore-rule block explains reason and unblock path...` → red); with it applied, green. The new test also covers the ignored-and-deleted case (no existence claim) and the internal-edit secret gate.

## Validation

On mirror `0d2d7a085` (branch rebased onto latest `main`; branch base `f5adf610f` touched no PR file — `git diff f5adf610f..0d2d7a085 --name-only -- sdk/` lists only `sdk/test/setup-env.ts`, re-gated after rebase):

- `cd sdk && CI=true bun run test` — **537 pass / 0 fail** (sdk is clean on main; unchanged).
- `cd sdk && bun run typecheck` — 0 errors (baseline 0).
- `cd cli && CI=true bun run test` — 2848 pass / 13 fail / 11 errors of 2871; failure **set** identical to the known-red baseline (3 × `* release wrapper contains only product configuration and package loading` + unloadable `packages/internal`/`tar` files). No new failures.
- `bun x prettier --check` on the touched files (incl. `sdk/README.md`): `read-files.ts`, `run-file-filter.test.ts`, and `README.md` clean; `read-files.test.ts` has exactly one dirty line, the pre-existing `bigFile` wrap at ~line 841 that this diff does not touch — no new warnings from changed lines.
- `bun run build:sdk` and `bun run build:freebuff` — both succeed.
- Consumer audit: no exact `=== '[BLOCKED]'` comparisons exist anywhere in the public tree (grep for the literal finds only the constant definition); `toOptionalFile`/`HIDDEN_FILE_READ_STATUS` use `startsWith`; `agent-runtime` (`render-read-files-result.ts`, `getPreviouslyReadFiles`) passes content through unmodified.
- Runtime: gates re-verified under the repo-pinned Bun `1.3.14` (`.bun-version`) via `bunx bun@1.3.14` — sdk suite, typecheck, prettier, and the cli failure set match the numbers above, which were first measured on local Bun 1.4.0.
