### PR TITLE
fix(sdk): use max instead of sum for OpenRouter cost fields

### DIFF
--- a/sdk/src/impl/__tests__/usage-receipts.test.ts
+++ b/sdk/src/impl/__tests__/usage-receipts.test.ts
@@ -103,7 +103,8 @@ describe('stream usage receipts', () => {
       },
     ])
     expect(costs).toHaveLength(1)
-    expect(costs[0]).toBeGreaterThan(0)
+    // max(0.01, 0.02) * 1.055 * 100 = 2.11, rounded to 2
+    expect(costs[0]).toBe(2)
     expect(callbackOrder).toEqual(['usage', 'cost'])
   })
 

--- a/sdk/src/impl/llm.ts
+++ b/sdk/src/impl/llm.ts
@@ -392,8 +392,10 @@ export async function* promptAiSdkStream(
       | OpenRouterUsageAccounting
       | undefined
     const costOverrideDollars = openrouterUsage
-      ? (openrouterUsage.cost ?? 0) +
-        (openrouterUsage.costDetails?.upstreamInferenceCost ?? 0)
+      ? Math.max(
+          openrouterUsage.cost ?? 0,
+          openrouterUsage.costDetails?.upstreamInferenceCost ?? 0,
+        )
       : undefined
     if (!params.onCostCalculated || !costOverrideDollars) return
     costReported = true
@@ -732,9 +734,10 @@ export async function promptAiSdk(
       const openrouterUsage = providerMetadata.codebuff
         .usage as OpenRouterUsageAccounting
 
-      costOverrideDollars =
-        (openrouterUsage.cost ?? 0) +
-        (openrouterUsage.costDetails?.upstreamInferenceCost ?? 0)
+      costOverrideDollars = Math.max(
+        openrouterUsage.cost ?? 0,
+        openrouterUsage.costDetails?.upstreamInferenceCost ?? 0,
+      )
     }
   }
 
@@ -803,9 +806,10 @@ export async function promptAiSdkStructured<T>(
       const openrouterUsage = providerMetadata.codebuff
         .usage as OpenRouterUsageAccounting
 
-      costOverrideDollars =
-        (openrouterUsage.cost ?? 0) +
-        (openrouterUsage.costDetails?.upstreamInferenceCost ?? 0)
+      costOverrideDollars = Math.max(
+        openrouterUsage.cost ?? 0,
+        openrouterUsage.costDetails?.upstreamInferenceCost ?? 0,
+      )
     }
   }
 


### PR DESCRIPTION
All three cost-calculation paths in the SDK (promptAiSdkStream, promptAiSdk, promptAiSdkStructured) sum usage.cost and cost_details.upstream_inference_cost to derive the dollar amount charged as credits. Per OpenRouter's accounting, usage.cost is the total charge and upstream_inference_cost is the upstream component already included in that total -- so summing them roughly doubles the true spend on non-BYOK routes.

Changed the aggregation from cost + upstream to Math.max(cost, upstream), which returns the correct value in both shapes:

Normal route: cost is the authoritative total (includes upstream + margin); upstream < cost; max picks cost.
BYOK route: cost is 0; upstream carries the real spend; max picks upstream.

This matches the server-side extractUsageAndCost semantics documented in common/src/constants/freebuff-models.ts.

Existing usage-receipts.test.ts passes (strengthened the assertion from > 0 to exact expected credits). TypeScript compiles clean.

Fixes #1164