### PR TITLE
fix(agent-runtime): stop run after local prompt config errors

### DIFF
--- a/packages/agent-runtime/src/__tests__/call-main-prompt.test.ts
+++ b/packages/agent-runtime/src/__tests__/call-main-prompt.test.ts
@@ -1,0 +1,86 @@
+import { TEST_USER_ID } from '@codebuff/common/old-constants'
+import { createTestAgentRuntimeParams } from '@codebuff/common/testing/fixtures/agent-runtime'
+import { getInitialSessionState } from '@codebuff/common/types/session-state'
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+import { callMainPrompt } from '../main-prompt'
+import * as agentRegistry from '../templates/agent-registry'
+
+import type { ProjectFileContext } from '@codebuff/common/util/file'
+
+describe('callMainPrompt', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  const mockFileContext: ProjectFileContext = {
+    projectRoot: '/test',
+    cwd: '/test',
+    fileTree: [],
+    fileTokenScores: {},
+    knowledgeFiles: {},
+    gitChanges: {
+      status: '',
+      diff: '',
+      diffCached: '',
+      lastCommitMessages: '',
+    },
+    changesSinceLastChat: {},
+    shellConfigFiles: {},
+    agentTemplates: {},
+    customToolDefinitions: {},
+    systemInfo: {
+      platform: 'test',
+      shell: 'test',
+      nodeVersion: 'test',
+      arch: 'test',
+      homedir: '/home/test',
+      cpus: 1,
+      chromeAvailable: false,
+    },
+  }
+
+  it('returns early without calling mainPrompt when agent config validation fails', async () => {
+    const sentActions: Array<{ type: string }> = []
+    const sendAction = ({ action }: { action: { type: string } }) => {
+      sentActions.push(action)
+    }
+
+    spyOn(agentRegistry, 'assembleLocalAgentTemplates').mockReturnValue({
+      agentTemplates: {},
+      validationErrors: [
+        { message: 'bad agent config', agentId: 'test-agent' },
+      ] as any,
+    })
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const baseParams = createTestAgentRuntimeParams()
+
+    const result = await callMainPrompt({
+      ...baseParams,
+      promptId: 'test-prompt',
+      sendAction,
+      logger: baseParams.logger,
+      signal: new AbortController().signal,
+      action: {
+        type: 'prompt' as const,
+        prompt: 'Hello',
+        sessionState,
+        fingerprintId: 'test',
+        costMode: 'normal' as const,
+        promptId: 'test-prompt',
+        toolResults: [],
+      },
+      repoUrl: undefined,
+      repoId: undefined,
+      clientSessionId: 'test-session',
+      userId: TEST_USER_ID,
+    } as any)
+
+    const actionTypes = sentActions.map((a) => a.type)
+    expect(actionTypes).toContain('prompt-error')
+    expect(actionTypes).toContain('prompt-response')
+    expect(actionTypes).not.toContain('response-chunk')
+    expect(result.output.type).toBe('error')
+  })
+})

--- a/packages/agent-runtime/src/main-prompt.ts
+++ b/packages/agent-runtime/src/main-prompt.ts
@@ -171,13 +171,32 @@ export async function callMainPrompt(
     assembleLocalAgentTemplates({ fileContext, logger })
 
   if (validationErrors.length > 0) {
+    const errorMessage = `Invalid agent config: ${validationErrors.map((err) => err.message).join('\n')}`
     sendAction({
       action: {
         type: 'prompt-error',
-        message: `Invalid agent config: ${validationErrors.map((err) => err.message).join('\n')}`,
+        message: errorMessage,
         userInputId: promptId,
       },
     })
+
+    const errorResult = {
+      sessionState: action.sessionState,
+      output: { type: 'error' as const, message: errorMessage },
+    }
+
+    sendAction({
+      action: {
+        type: 'prompt-response',
+        promptId,
+        sessionState: errorResult.sessionState,
+        toolCalls: [],
+        toolResults: [],
+        output: errorResult.output,
+      },
+    })
+
+    return errorResult
   }
 
   sendAction({


### PR DESCRIPTION
When assembleLocalAgentTemplates returns validation errors, callMainPrompt now returns early with an error result and a prompt-response action, instead of continuing into mainPrompt. Before this the orphaned run kept executing after the prompt-error banner -- burning credits, executing tools, and mutating shared state while the UI already showed the error.

Also adds a regression test verifying early return on validation errors.

Fixes the "prompt-error orphans the run" sub-bug from #1155.

Tested with a new call-main-prompt.test.ts that verifies prompt-error and prompt-response are sent, no response-chunk events fire, and the result is an error. Existing main-prompt.test.ts tests still pass.