### PR TITLE
Fix Zod v4 schema description crash in agent-runtime

### DIFF
--- a/packages/agent-runtime/src/__tests__/prompts-schema-handling.test.ts
+++ b/packages/agent-runtime/src/__tests__/prompts-schema-handling.test.ts
@@ -202,7 +202,7 @@ describe('Schema handling error recovery', () => {
       expect(description).toContain('content')
     })
 
-    test('buildToolDescription preserves MCP params when schema is represented as allOf', () => {
+    test('buildToolDescription preserves MCP params from converted schema', () => {
       const mcpSchema = convertJsonSchemaToZod({
         type: 'object',
         properties: {
@@ -221,8 +221,8 @@ describe('Schema handling error recovery', () => {
 
       expect(description).toContain('greet__greet')
       expect(description).toContain('Params: {')
-      expect(description).toContain('allOf')
       expect(description).toContain('name')
+      expect(description).toContain('cb_easp')
       expect(description).not.toContain('Params: None')
     })
 

--- a/packages/agent-runtime/src/templates/prompts.ts
+++ b/packages/agent-runtime/src/templates/prompts.ts
@@ -16,7 +16,11 @@ function ensureJsonSchemaCompatible(schema: z.ZodType): z.ZodType {
     return schema
   } catch {
     const fallback = z.object({}).passthrough()
-    return schema.description ? fallback.describe(schema.description) : fallback
+    try {
+      return schema.description ? fallback.describe(schema.description) : fallback
+    } catch {
+      return fallback
+    }
   }
 }
 

--- a/packages/agent-runtime/src/tools/prompts.ts
+++ b/packages/agent-runtime/src/tools/prompts.ts
@@ -43,7 +43,11 @@ function ensureJsonSchemaCompatible(schema: z.ZodType): z.ZodType {
     return schema
   } catch {
     const fallback = z.object({}).passthrough()
-    return schema.description ? fallback.describe(schema.description) : fallback
+    try {
+      return schema.description ? fallback.describe(schema.description) : fallback
+    } catch {
+      return fallback
+    }
   }
 }
 


### PR DESCRIPTION
## Problem & Context

In `packages/agent-runtime`, `ensureJsonSchemaCompatible(schema: z.ZodType)` recovers from non-serializable schemas (such as `z.function()`) by generating a passthrough fallback object and copying the schema's description:

```ts
return schema.description ? fallback.describe(schema.description) : fallback
```

Under Zod v4, accessing the `.description` getter on a function schema evaluates `schema._zod.parent`. Because `parent` is undefined for function schemas, this throws an unhandled `TypeError: undefined is not an object (evaluating 'schema._zod.parent')` inside the recovery handler, crashing `getToolSet` and failing unit tests in `prompts-schema-handling.test.ts`.

Additionally, under Zod v4, `.and()` directly merges intersected object schema properties into the top-level properties instead of wrapping them in an `allOf` construct.

## Changes Made

- Guarded `schema.description` access in a nested `try / catch` block within `ensureJsonSchemaCompatible()` in both `packages/agent-runtime/src/tools/prompts.ts` and `packages/agent-runtime/src/templates/prompts.ts`, ensuring non-serializable schemas return the fallback object cleanly without throwing.
- Updated `prompts-schema-handling.test.ts` to assert that converted MCP parameter properties (`name`, `cb_easp`) are preserved.

## Architecture & Conventions Conformance

- [x] Adheres to Dependency Injection (contracts defined in `common/src/types/contracts/`, no module monkey patching)
- [x] Terminal commands use `terminalCommandBroker` (no direct `spawn` or TUI-process bypass)
- [x] Environment hygiene respected (`getCliEnv()` for CLI, `getSdkEnv()` for SDK, no forbidden `getProcessEnv()` imports)
- [x] Freebuff mode compatibility (`IS_FREEBUFF` preserved, no paid features introduced)
- [x] Imports ordered and explicit (`import type` used for types)

## Scope Verification

- [x] All modified files are within allowed public directories: `packages/agent-runtime/`
- [x] NO modifications to `web/`, `freebuff/web/`, `packages/internal/`, `packages/billing/`, `packages/bigquery/`, or `packages/build-tools/`

## Testing & Verification

- [x] `bun test packages/agent-runtime/src/__tests__/prompts-schema-handling.test.ts` passed 15/15 tests (was failing 2 tests).
- [x] `bun run build:sdk` passed cleanly.
- [x] `bun run build:freebuff` passed cleanly.
- [x] `bun cli/scripts/smoke-binary.ts cli/bin/freebuff` passed cleanly.
- [x] Anti-flake principles observed.
