### PR TITLE
Fix dead agents-graveyard test imports in agent-runtime

### DIFF
--- a/packages/agent-runtime/src/__tests__/read-docs-tool.test.ts
+++ b/packages/agent-runtime/src/__tests__/read-docs-tool.test.ts
@@ -14,7 +14,8 @@ import {
 } from 'bun:test'
 
 import { createToolCallChunk, mockFileContext } from './test-utils'
-import researcherAgent from '../../../../agents-graveyard/researcher/researcher'
+import researcherDocsAgent from '../../../../agents/researcher/researcher-docs'
+const researcherAgent = { ...researcherDocsAgent, id: 'researcher' }
 import * as webApi from '../llm-api/codebuff-web-api'
 import { runAgentStep } from '../run-agent-step'
 import { assembleLocalAgentTemplates } from '../templates/agent-registry'

--- a/packages/agent-runtime/src/__tests__/web-search-tool.test.ts
+++ b/packages/agent-runtime/src/__tests__/web-search-tool.test.ts
@@ -14,7 +14,8 @@ import {
 } from 'bun:test'
 
 import { createToolCallChunk, mockFileContext } from './test-utils'
-import researcherAgent from '../../../../agents-graveyard/researcher/researcher'
+import researcherWebAgent from '../../../../agents/researcher/researcher-web'
+const researcherAgent = { ...researcherWebAgent, id: 'researcher' }
 import * as webApi from '../llm-api/codebuff-web-api'
 import { runAgentStep } from '../run-agent-step'
 import { assembleLocalAgentTemplates } from '../templates/agent-registry'


### PR DESCRIPTION
## Problem & Context

Running TypeScript typechecking on `packages/agent-runtime` (`bun run typecheck`) failed with 2 compilation errors:

```
src/__tests__/read-docs-tool.test.ts:17:29 - error TS2307: Cannot find module '../../../../agents-graveyard/researcher/researcher' or its corresponding type declarations.
src/__tests__/web-search-tool.test.ts:17:29 - error TS2307: Cannot find module '../../../../agents-graveyard/researcher/researcher' or its corresponding type declarations.
```

The `agents-graveyard` directory was an archived internal path that was never exported to the public repository. Both test suites crashed at import when executed in the public codebase.

## Changes Made

- In `packages/agent-runtime/src/__tests__/read-docs-tool.test.ts`: Replaced the dead `agents-graveyard` import with the active public definition from `agents/researcher/researcher-docs.ts`.
- In `packages/agent-runtime/src/__tests__/web-search-tool.test.ts`: Replaced the dead `agents-graveyard` import with the active public definition from `agents/researcher/researcher-web.ts`.

## Architecture & Conventions Conformance

- [x] Adheres to Dependency Injection (contracts defined in `common/src/types/contracts/`, no module monkey patching)
- [x] Terminal commands use `terminalCommandBroker` (no direct `spawn` or TUI-process bypass)
- [x] Environment hygiene respected (`getCliEnv()` for CLI, `getSdkEnv()` for SDK, no forbidden `getProcessEnv()` imports)
- [x] Freebuff mode compatibility (`IS_FREEBUFF` preserved, no paid features introduced)
- [x] Imports ordered and explicit (`import type` used for types)

## Scope Verification

- [x] All modified files are within allowed public directories: `packages/agent-runtime/src/__tests__/`
- [x] NO modifications to `web/`, `freebuff/web/`, `packages/internal/`, `packages/billing/`, `packages/bigquery/`, or `packages/build-tools/`

## Testing & Verification

- [x] `bun run --cwd packages/agent-runtime typecheck` passed with 0 errors (was 2 errors).
- [x] `bun test packages/agent-runtime/src/__tests__/read-docs-tool.test.ts packages/agent-runtime/src/__tests__/web-search-tool.test.ts` passed 15/15 tests (was failing due to missing module).
- [x] `bun run build:sdk` passed cleanly.
- [x] `bun run build:freebuff` passed cleanly.
- [x] `bun cli/scripts/smoke-binary.ts cli/bin/freebuff` passed cleanly.
- [x] Anti-flake principles observed.
