### PR TITLE
Fix CLI test runner preload and test-utils fallback for public mirror

### DIFF
--- a/cli/bunfig.toml
+++ b/cli/bunfig.toml
@@ -13,6 +13,5 @@
 # which is why CI filters those with `find ... ! -name` instead.
 preload = [
   "../sdk/test/setup-env.ts",
-  "../test/setup-scm-loader.ts",
   "./test/setup-agents-artifact.ts",
 ]

--- a/cli/src/__tests__/test-utils.ts
+++ b/cli/src/__tests__/test-utils.ts
@@ -121,23 +121,30 @@ function loadCliEnv(): Record<string, string> {
 
   try {
     ensureCliEnvDefaults()
-    // NOTE: Inline require() is used for lazy loading - the env module depends on
-    // Infisical secrets which may not be available at module load time in test environments
-    const { env } = require('../../../packages/internal/src/env') as {
-      env: Record<string, unknown>
+    try {
+      const { env } = require('../../../packages/internal/src/env') as {
+        env: Record<string, unknown>
+      }
+
+      cachedEnv = Object.entries(env).reduce<Record<string, string>>(
+        (acc, [key, value]) => {
+          if (value !== undefined && value !== null) {
+            acc[key] = String(value)
+          }
+          return acc
+        },
+        {},
+      )
+
+      return cachedEnv
+    } catch {
+      // Fallback for public mirror where packages/internal is not present
+      cachedEnv = {
+        ...TEST_CLIENT_ENV_DEFAULTS,
+        ...TEST_SERVER_ENV_DEFAULTS,
+      }
+      return cachedEnv
     }
-
-    cachedEnv = Object.entries(env).reduce<Record<string, string>>(
-      (acc, [key, value]) => {
-        if (value !== undefined && value !== null) {
-          acc[key] = String(value)
-        }
-        return acc
-      },
-      {},
-    )
-
-    return cachedEnv
   } catch (error) {
     const message =
       error instanceof Error


### PR DESCRIPTION
## Problem & Context

Running CLI tests via Bun on the public repository failed immediately with two blocking issues:

1. **Missing Preload in `cli/bunfig.toml`**: `cli/bunfig.toml` declared `../test/setup-scm-loader.ts` under `preload`. The root `test/` directory was unbundled from the public mirror in commit `61bbbed7`, causing any invocation of `bun test` in `cli` to crash at startup before running any test files:
   ```
   error: preload not found "../test/setup-scm-loader.ts"
   ```
   (Modern Bun loads `.scm` text queries natively without requiring an external loader plugin).

2. **Missing `packages/internal` in `cli/src/__tests__/test-utils.ts`**: When test suites invoked `ensureCliTestEnv()`, `loadCliEnv()` attempted to require `../../../packages/internal/src/env`. Because `packages/internal` is an unexported private module omitted from the public repository, this threw an unhandled error (`Cannot find module '../../../packages/internal/src/env'`) instead of utilizing the defined test defaults (`TEST_CLIENT_ENV_DEFAULTS` and `TEST_SERVER_ENV_DEFAULTS`).

## Changes Made

- **`cli/bunfig.toml`**: Removed the non-existent `../test/setup-scm-loader.ts` entry from `preload`.
- **`cli/src/__tests__/test-utils.ts`**: Wrapped the dynamic `require('../../../packages/internal/src/env')` in a fallback block that initializes `cachedEnv` with `TEST_CLIENT_ENV_DEFAULTS` and `TEST_SERVER_ENV_DEFAULTS` when running on the public repository.

## Architecture & Conventions Conformance

- [x] Adheres to Dependency Injection (contracts defined in `common/src/types/contracts/`, no module monkey patching)
- [x] Terminal commands use `terminalCommandBroker` (no direct `spawn` or TUI-process bypass)
- [x] Environment hygiene respected (`getCliEnv()` for CLI, `getSdkEnv()` for SDK, no forbidden `getProcessEnv()` imports)
- [x] Freebuff mode compatibility (`IS_FREEBUFF` preserved, no paid features introduced)
- [x] Imports ordered and explicit (`import type` used for types)

## Scope Verification

- [x] All modified files are within allowed public directories: `cli/`
- [x] NO modifications to `web/`, `freebuff/web/`, `packages/internal/`, `packages/billing/`, `packages/bigquery/`, or `packages/build-tools/`

## Testing & Verification

- [x] `bun run --cwd cli typecheck` passed with 0 errors.
- [x] `bun test src/__tests__/cli-args.test.ts` passed 15/15 tests (was crashing on missing preload).
- [x] `bun test src/__tests__/launcher-disconnect.test.ts` passed (was crashing on missing `packages/internal`).
- [x] `bun test src/__tests__/launcher-avx2-fallback.test.ts` passed 31/31 tests.
- [x] `bun test src/__tests__/unit/` passed 85/85 tests.
- [x] `bun run build:sdk` passed cleanly.
- [x] `bun run build:freebuff` passed cleanly.
- [x] `bun cli/scripts/smoke-binary.ts cli/bin/freebuff` passed cleanly.
- [x] Anti-flake principles observed.
