### PR TITLE
Fix Pino type imports and destination in evals logger

### DIFF
--- a/evals/logger.ts
+++ b/evals/logger.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from 'fs'
 import path, { dirname } from 'path'
 
 import { IS_CI, IS_TEST } from '@codebuff/common/env'
-import { pino } from 'pino'
+import pino, { type LogFn } from 'pino'
 
 let logPath: string | undefined = undefined
 let pinoLogger: any = undefined
@@ -57,7 +57,7 @@ function log(level: LogLevel, data: any, msg?: string, ...args: any[]): void {
  *
  * e.g. logger.info({eventId: AnalyticsEvent.SOME_EVENT, field: value}, 'some message')
  */
-export const logger: Record<LogLevel, pino.LogFn> = Object.fromEntries(
+export const logger: Record<LogLevel, LogFn> = Object.fromEntries(
   loggingLevels.map((level) => {
     return [
       level,
@@ -65,4 +65,4 @@ export const logger: Record<LogLevel, pino.LogFn> = Object.fromEntries(
         log(level, data, msg, ...args),
     ]
   }),
-) as Record<LogLevel, pino.LogFn>
+) as Record<LogLevel, LogFn>


### PR DESCRIPTION
# Fix Pino type imports and destination in evals logger

## Summary

• Fixes TypeScript typechecking errors in `evals/logger.ts` where `pino.destination` and `pino.LogFn` caused 3 `tsc` compilation failures:
  - `Property 'destination' does not exist on type 'typeof pino'`
  - `Namespace 'pino.pino' has no exported member 'LogFn'` (x2)
• In Pino v9, `pino.destination` resides on the default export (`import pino from 'pino'`), while `LogFn` is exported directly as a top-level type (`import { type LogFn } from 'pino'`).
• Updates `logger.ts` to import `pino, { type LogFn } from 'pino'` and reference `Record<LogLevel, LogFn>`.
• Unlocks clean `bun run --cwd evals typecheck` (0 errors) across the evaluation benchmark harness.

## Test plan

[✓] Ran `bun run --cwd evals typecheck` — 0 errors (previously 3 errors in `logger.ts`)
[✓] Verified runtime logging functions normally with `pino.destination`
