### PR TITLE
Direct launcher crash reports to product issues tracker

### DIFF
--- a/cli/release-core/launcher.js
+++ b/cli/release-core/launcher.js
@@ -1141,7 +1141,7 @@ function createLauncher(productConfig) {
     }
     console.error('')
     console.error('Please report this issue at:')
-    console.error('  https://github.com/CodebuffAI/codebuff/issues')
+    console.error(`  https://github.com/CodebuffAI/${packageName}/issues`)
     console.error('')
   }
 

--- a/cli/src/__tests__/release/wrapper-safety.test.ts
+++ b/cli/src/__tests__/release/wrapper-safety.test.ts
@@ -399,4 +399,50 @@ describe('shared release launcher safety', () => {
     )
     expect(runningProcess.listenerCount('exit')).toBe(0)
   })
+
+  test('directs crash reports to the product repository issues tracker', () => {
+    const freebuffLauncher = createLauncher({
+      packageName: 'freebuff',
+      displayName: 'Freebuff',
+    })
+    const codebuffLauncher = createLauncher({
+      packageName: 'codebuff',
+      displayName: 'Codebuff',
+    })
+
+    const freebuffErrors: string[] = []
+    const codebuffErrors: string[] = []
+
+    const originalConsoleError = console.error
+    try {
+      console.error = (...args: unknown[]) => {
+        freebuffErrors.push(args.join(' '))
+      }
+      freebuffLauncher.__testing.printCrashDiagnostics(null, 'SIGSEGV')
+
+      console.error = (...args: unknown[]) => {
+        codebuffErrors.push(args.join(' '))
+      }
+      codebuffLauncher.__testing.printCrashDiagnostics(null, 'SIGSEGV')
+    } finally {
+      console.error = originalConsoleError
+    }
+
+    expect(
+      freebuffErrors.some((line) =>
+        line.includes('https://github.com/CodebuffAI/freebuff/issues'),
+      ),
+    ).toBe(true)
+    expect(
+      freebuffErrors.some((line) =>
+        line.includes('https://github.com/CodebuffAI/codebuff/issues'),
+      ),
+    ).toBe(false)
+
+    expect(
+      codebuffErrors.some((line) =>
+        line.includes('https://github.com/CodebuffAI/codebuff/issues'),
+      ),
+    ).toBe(true)
+  })
 })


### PR DESCRIPTION
# Direct launcher crash reports to product issues tracker

## Summary

• In `cli/release-core/launcher.js`, parameterize the issue tracker URL in `printCrashDiagnostics` with `packageName` (`https://github.com/CodebuffAI/${packageName}/issues`).
• Previously, `printCrashDiagnostics` dynamically parameterized diagnostic outputs with `${packageName}` and `${packageName.toUpperCase()}_BINARY_TARGET`, but hardcoded `https://github.com/CodebuffAI/codebuff/issues` for the issue reporting URL.
• When Freebuff CLI users experience an immediate exit or native crash (e.g. on unsupported CPUs, missing GLIBC, or missing AVX2), they were instructed to report the issue at `CodebuffAI/codebuff` rather than `CodebuffAI/freebuff`.
• Adds a regression test in `cli/src/__tests__/release/wrapper-safety.test.ts` verifying that `printCrashDiagnostics` outputs the product-specific issue tracker URL for `freebuff` and `codebuff`.

## Test plan

[✓] `bun test --config=/dev/null src/__tests__/release/wrapper-safety.test.ts` — 18 pass, 0 fail (including new issue URL regression test)
[✓] `bun run --cwd cli typecheck` — 0 errors
[✓] `node --check cli/release-core/launcher.js` — syntax valid
[✓] PR hygiene check passed
