### PR TITLE
Support relative and absolute path keys in fileWindows lookup

### DIFF
--- a/sdk/src/__tests__/read-files.test.ts
+++ b/sdk/src/__tests__/read-files.test.ts
@@ -848,5 +848,56 @@ describe('getFiles', () => {
       expect(result['src/big.ts']).toContain('showing lines 10-14 of 3000')
       expect(result['src/big.ts']).toContain('showing lines 2500-2504 of 3000')
     })
+
+    test('resolves fileWindows keyed by relative path when filePaths has leading dot-slash', async () => {
+      const mockFs = createMockFs({
+        files: { '/project/src/big.ts': { content: bigFile } },
+      })
+
+      const result = await getFiles({
+        filePaths: ['./src/big.ts'],
+        cwd: '/project',
+        fs: mockFs,
+        fileWindows: { 'src/big.ts': [{ offset: 2500, limit: 10 }] },
+      })
+
+      expect(result['src/big.ts']).toContain('line 2500')
+      expect(result['src/big.ts']).toContain('showing lines 2500-2509 of 3000')
+      expect(result['src/big.ts']).not.toContain('line 100\n')
+    })
+
+    test('resolves fileWindows keyed by relative path when filePaths has absolute path', async () => {
+      const mockFs = createMockFs({
+        files: { '/project/src/big.ts': { content: bigFile } },
+      })
+
+      const result = await getFiles({
+        filePaths: ['/project/src/big.ts'],
+        cwd: '/project',
+        fs: mockFs,
+        fileWindows: { 'src/big.ts': [{ offset: 2500, limit: 10 }] },
+      })
+
+      expect(result['src/big.ts']).toContain('line 2500')
+      expect(result['src/big.ts']).toContain('showing lines 2500-2509 of 3000')
+      expect(result['src/big.ts']).not.toContain('line 100\n')
+    })
+
+    test('resolves fileWindows keyed by absolute path when filePaths has relative path', async () => {
+      const mockFs = createMockFs({
+        files: { '/project/src/big.ts': { content: bigFile } },
+      })
+
+      const result = await getFiles({
+        filePaths: ['src/big.ts'],
+        cwd: '/project',
+        fs: mockFs,
+        fileWindows: { '/project/src/big.ts': [{ offset: 2500, limit: 10 }] },
+      })
+
+      expect(result['src/big.ts']).toContain('line 2500')
+      expect(result['src/big.ts']).toContain('showing lines 2500-2509 of 3000')
+      expect(result['src/big.ts']).not.toContain('line 100\n')
+    })
   })
 })

--- a/sdk/src/tools/read-files.ts
+++ b/sdk/src/tools/read-files.ts
@@ -116,7 +116,10 @@ export async function getFiles(params: {
 
       const content = await fs.readFile(fullPath, 'utf8')
 
-      const windows = fileWindows?.[filePath]
+      const windows =
+        fileWindows?.[filePath] ??
+        fileWindows?.[relativePath] ??
+        (fullPath ? fileWindows?.[fullPath] : undefined)
       const windowedContent =
         limitContent && fileWindows !== undefined
           ? (windows?.length ? windows : [{}])


### PR DESCRIPTION
# Support relative and absolute path keys in fileWindows lookup

## Summary

• In `sdk/src/tools/read-files.ts`, resolve `fileWindows` using `filePath`, `relativePath`, or `fullPath`.
• Previously, `windows` was looked up strictly via `fileWindows?.[filePath]`. If `filePaths` contained an alias (e.g. `./src/file.ts` or an absolute path `/cwd/src/file.ts`) while `fileWindows` was keyed by the canonical `relativePath` (`src/file.ts`), or vice versa, the lookup evaluated to `undefined`.
• When `windows` is `undefined` while `fileWindows` is enabled, the code defaulted to `[{}]`, dumping the whole file from line 1 and discarding the model's requested window offset/limit.
• Adding fallback lookups for `fileWindows?.[relativePath]` and `fileWindows?.[fullPath]` ensures requested windows are accurately applied regardless of path format.
• Adds regression tests in `sdk/src/__tests__/read-files.test.ts` verifying window resolution across relative, dot-slash, and absolute path variations.

## Test plan

[✓] `bun test src/__tests__/read-files.test.ts` — 40 pass, 0 fail
[✓] `bun run --cwd sdk typecheck` — 0 errors
[✓] PR hygiene check passed
