### PR TITLE
Bound lines array in getLastNVisualLines to prevent unbounded memory growth

### DIFF
--- a/cli/src/utils/__tests__/text-layout.test.ts
+++ b/cli/src/utils/__tests__/text-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 
-import { computeInputLayoutMetrics } from '../text-layout'
+import { computeInputLayoutMetrics, getLastNVisualLines } from '../text-layout'
 
 describe('computeInputLayoutMetrics', () => {
   test('single-line content keeps height at 1 without gutter', () => {
@@ -78,5 +78,41 @@ describe('computeInputLayoutMetrics', () => {
 
     expect(metrics.heightLines).toBe(2)
     expect(metrics.gutterEnabled).toBe(false)
+  })
+})
+
+describe('getLastNVisualLines', () => {
+  test('returns empty array when n or cols <= 0 or text is empty', () => {
+    expect(getLastNVisualLines('', 40, 5)).toEqual({ lines: [], hasMore: false })
+    expect(getLastNVisualLines('hello', 0, 5)).toEqual({ lines: [], hasMore: false })
+    expect(getLastNVisualLines('hello', 40, 0)).toEqual({ lines: [], hasMore: false })
+  })
+
+  test('returns all lines without hasMore when line count <= n', () => {
+    const text = 'line 1\nline 2\nline 3'
+    const result = getLastNVisualLines(text, 40, 5)
+    expect(result.lines).toEqual(['line 1', 'line 2', 'line 3'])
+    expect(result.hasMore).toBe(false)
+  })
+
+  test('returns only last n lines with hasMore = true when line count > n', () => {
+    const text = 'line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7'
+    const result = getLastNVisualLines(text, 40, 3)
+    expect(result.lines).toEqual(['line 5', 'line 6', 'line 7'])
+    expect(result.hasMore).toBe(true)
+  })
+
+  test('correctly bounds array when text has hundreds of wrapped lines', () => {
+    const text = Array.from({ length: 100 }, (_, i) => `Line ${i}`).join('\n')
+    const result = getLastNVisualLines(text, 40, 4)
+    expect(result.lines).toEqual(['Line 96', 'Line 97', 'Line 98', 'Line 99'])
+    expect(result.hasMore).toBe(true)
+  })
+
+  test('wraps long lines exceeding column width', () => {
+    const text = 'supercalifragilisticexpialidocious'
+    const result = getLastNVisualLines(text, 10, 2)
+    expect(result.lines.length).toBe(2)
+    expect(result.hasMore).toBe(true)
   })
 })

--- a/cli/src/utils/text-layout.ts
+++ b/cli/src/utils/text-layout.ts
@@ -62,11 +62,16 @@ export function getLastNVisualLines(text: string, cols: number, n: number): { li
   const lines: string[] = []
   if (!text) return { lines, hasMore: false }
 
+  let hasMore = false
   const tokens = text.split(/(\s+)/)
   let current = ''
   let currentWidth = 0
 
   const pushLine = () => {
+    if (lines.length === n) {
+      hasMore = true
+      lines.shift()
+    }
     lines.push(current)
     current = ''
     currentWidth = 0
@@ -104,10 +109,8 @@ export function getLastNVisualLines(text: string, cols: number, n: number): { li
     appendSegment(token)
   }
 
-  if (current.length > 0 || lines.length === 0) pushLine()
-  const hasMore = lines.length > n
-  const lastLines = lines.slice(-n)
-  return { lines: lastLines, hasMore }
+  if (current.length > 0 || (!hasMore && lines.length === 0)) pushLine()
+  return { lines, hasMore }
 }
 
 export function computeInputLayoutMetrics({


### PR DESCRIPTION
# Bound lines array in getLastNVisualLines to prevent unbounded memory growth

## Summary

• In `cli/src/utils/text-layout.ts`, bound the `lines` accumulator in `getLastNVisualLines` to at most `n` lines.
• Previously, `getLastNVisualLines` accumulated every wrapped line from character 0 to the end of the text in `lines: string[]`, only to slice `lines.slice(-n)` at the very end and discard the rest. When rendering long reasoning blocks, assistant messages, or terminal logs (e.g. 500+ lines), this held hundreds of unnecessary line strings in memory and required an additional `.slice()` array allocation.
• Updated `pushLine()` to evict the oldest line whenever `lines.length === n` and set `hasMore = true`, ensuring memory used by `lines` is strictly bounded by $O(n)$ ($n \le 5$ in preview) rather than $O(\text{total lines})$.
• Added comprehensive unit tests in `cli/src/utils/__tests__/text-layout.test.ts` covering zero column/line inputs, small line counts, wrapping boundaries, and multi-hundred line inputs.

## Test plan

[✓] `bun test --config=/dev/null src/utils/__tests__/text-layout.test.ts` — 11 pass, 0 fail
[✓] `bun run --cwd cli typecheck` — 0 errors
[✓] PR hygiene check passed
