### PR TITLE
Add shallow equality guards to MessageBlockStore to prevent unnecessary renders

### DIFF
--- a/cli/src/chat.tsx
+++ b/cli/src/chat.tsx
@@ -61,7 +61,10 @@ import { useChatStore } from './state/chat-store'
 import { useQueuePanelStore } from './state/queue-panel-store'
 import { useReviewStore } from './state/review-store'
 import { useFeedbackStore } from './state/feedback-store'
-import { useMessageBlockStore } from './state/message-block-store'
+import {
+  useMessageBlockStore,
+  EMPTY_RESPONSE_ADS,
+} from './state/message-block-store'
 import { usePublishStore } from './state/publish-store'
 import { reportActivity } from './utils/activity-tracker'
 import { stopActiveRun } from './utils/active-run'
@@ -109,8 +112,6 @@ import type { BoxRenderable, ScrollBoxRenderable } from '@opentui/core'
 import type { UseMutationResult } from '@tanstack/react-query'
 import type { SponsoredProposalContentBlock } from './types/chat'
 import type { Dispatch, SetStateAction } from 'react'
-
-const EMPTY_RESPONSE_ADS: Record<string, AdResponse[]> = {}
 
 export const Chat = ({
   consumeInitialPrompt,

--- a/cli/src/chat.tsx
+++ b/cli/src/chat.tsx
@@ -49,7 +49,7 @@ import { useChatStreaming } from './hooks/use-chat-streaming'
 import { useChatUI } from './hooks/use-chat-ui'
 import { useClipboard } from './hooks/use-clipboard'
 import { useEvent } from './hooks/use-event'
-import { useGravityAd } from './hooks/use-gravity-ad'
+import { useGravityAd, type AdResponse } from './hooks/use-gravity-ad'
 import { useInputHistory } from './hooks/use-input-history'
 import { usePublishMutation } from './hooks/use-publish-mutation'
 import { useSuggestionEngine } from './hooks/use-suggestion-engine'
@@ -109,6 +109,8 @@ import type { BoxRenderable, ScrollBoxRenderable } from '@opentui/core'
 import type { UseMutationResult } from '@tanstack/react-query'
 import type { SponsoredProposalContentBlock } from './types/chat'
 import type { Dispatch, SetStateAction } from 'react'
+
+const EMPTY_RESPONSE_ADS: Record<string, AdResponse[]> = {}
 
 export const Chat = ({
   consumeInitialPrompt,
@@ -1487,7 +1489,7 @@ export const Chat = ({
       isWaitingForResponse,
       timerStartTime,
       availableWidth: messageAvailableWidth,
-      responseAds: showInlineAds ? responseAds : {},
+      responseAds: showInlineAds ? responseAds : EMPTY_RESPONSE_ADS,
     })
   }, [
     theme,

--- a/cli/src/state/__tests__/message-block-store.test.ts
+++ b/cli/src/state/__tests__/message-block-store.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { useMessageBlockStore } from '../message-block-store'
+
+describe('MessageBlockStore equality guards', () => {
+  beforeEach(() => {
+    useMessageBlockStore.getState().reset()
+  })
+
+  test('notifies subscribers when context property actually changes', () => {
+    let notifications = 0
+    const unsub = useMessageBlockStore.subscribe(() => {
+      notifications++
+    })
+
+    useMessageBlockStore.getState().setContext({ availableWidth: 120 })
+    expect(notifications).toBe(1)
+    expect(useMessageBlockStore.getState().context.availableWidth).toBe(120)
+
+    unsub()
+  })
+
+  test('does NOT notify subscribers when setContext is called with identical values', () => {
+    let notifications = 0
+    const unsub = useMessageBlockStore.subscribe(() => {
+      notifications++
+    })
+
+    // availableWidth is already 80 in initialContext
+    useMessageBlockStore.getState().setContext({ availableWidth: 80 })
+    expect(notifications).toBe(0)
+
+    // Call with existing isWaitingForResponse: false
+    useMessageBlockStore.getState().setContext({ isWaitingForResponse: false })
+    expect(notifications).toBe(0)
+
+    unsub()
+  })
+
+  test('does NOT notify subscribers when setCallbacks is called with identical callbacks', () => {
+    let notifications = 0
+    const currentCallbacks = useMessageBlockStore.getState().callbacks
+
+    const unsub = useMessageBlockStore.subscribe(() => {
+      notifications++
+    })
+
+    // Passing identical callbacks reference dictionary
+    useMessageBlockStore.getState().setCallbacks({ ...currentCallbacks })
+    expect(notifications).toBe(0)
+
+    // Modifying one callback triggers notification
+    const newFn = () => {}
+    useMessageBlockStore.getState().setCallbacks({
+      ...currentCallbacks,
+      onBuildFast: newFn,
+    })
+    expect(notifications).toBe(1)
+    expect(useMessageBlockStore.getState().callbacks.onBuildFast).toBe(newFn)
+
+    unsub()
+  })
+})

--- a/cli/src/state/__tests__/message-block-store.test.ts
+++ b/cli/src/state/__tests__/message-block-store.test.ts
@@ -60,4 +60,24 @@ describe('MessageBlockStore equality guards', () => {
 
     unsub()
   })
+
+  test('notifies subscribers when setCallbacks has fewer or different keys (full replacement semantics)', () => {
+    let notifications = 0
+    const currentCallbacks = useMessageBlockStore.getState().callbacks
+
+    const unsub = useMessageBlockStore.subscribe(() => {
+      notifications++
+    })
+
+    // Create a copy omitting one key
+    const subset = { ...currentCallbacks } as Partial<typeof currentCallbacks>
+    delete subset.onBuildFast
+
+    // Passing subset must count as changed because full replacement would remove onBuildFast
+    useMessageBlockStore.getState().setCallbacks(subset as any)
+    expect(notifications).toBe(1)
+    expect('onBuildFast' in useMessageBlockStore.getState().callbacks).toBe(false)
+
+    unsub()
+  })
 })

--- a/cli/src/state/message-block-store.ts
+++ b/cli/src/state/message-block-store.ts
@@ -154,11 +154,39 @@ export const useMessageBlockStore = create<MessageBlockStore>()(
 
     setContext: (updates) =>
       set((state) => {
+        let changed = false
+        for (const key of Object.keys(updates) as Array<keyof MessageBlockContext>) {
+          const prev = state.context[key]
+          const next = updates[key]
+          if (prev === next) continue
+          if (
+            key === 'responseAds' &&
+            prev &&
+            next &&
+            typeof prev === 'object' &&
+            typeof next === 'object' &&
+            Object.keys(prev).length === 0 &&
+            Object.keys(next).length === 0
+          ) {
+            continue
+          }
+          changed = true
+          break
+        }
+        if (!changed) return
         state.context = { ...state.context, ...updates }
       }),
 
     setCallbacks: (callbacks) =>
       set((state) => {
+        let changed = false
+        for (const key of Object.keys(callbacks) as Array<keyof MessageBlockCallbacks>) {
+          if (state.callbacks[key] !== callbacks[key]) {
+            changed = true
+            break
+          }
+        }
+        if (!changed) return
         state.callbacks = callbacks
       }),
 

--- a/cli/src/state/message-block-store.ts
+++ b/cli/src/state/message-block-store.ts
@@ -118,6 +118,8 @@ type MessageBlockStore = MessageBlockStoreState & MessageBlockStoreActions
 const noop = () => {}
 const noopFeedback: MessageBlockCallbacks['onFeedback'] = () => {}
 
+export const EMPTY_RESPONSE_ADS: Record<string, AdResponse[]> = {}
+
 const initialContext: MessageBlockContext = {
   theme: null,
   markdownPalette: null,
@@ -125,7 +127,7 @@ const initialContext: MessageBlockContext = {
   isWaitingForResponse: false,
   timerStartTime: null,
   availableWidth: 80,
-  responseAds: {},
+  responseAds: EMPTY_RESPONSE_ADS,
 }
 
 const initialCallbacks: MessageBlockCallbacks = {
@@ -156,22 +158,10 @@ export const useMessageBlockStore = create<MessageBlockStore>()(
       set((state) => {
         let changed = false
         for (const key of Object.keys(updates) as Array<keyof MessageBlockContext>) {
-          const prev = state.context[key]
-          const next = updates[key]
-          if (prev === next) continue
-          if (
-            key === 'responseAds' &&
-            prev &&
-            next &&
-            typeof prev === 'object' &&
-            typeof next === 'object' &&
-            Object.keys(prev).length === 0 &&
-            Object.keys(next).length === 0
-          ) {
-            continue
+          if (state.context[key] !== updates[key]) {
+            changed = true
+            break
           }
-          changed = true
-          break
         }
         if (!changed) return
         state.context = { ...state.context, ...updates }
@@ -179,8 +169,14 @@ export const useMessageBlockStore = create<MessageBlockStore>()(
 
     setCallbacks: (callbacks) =>
       set((state) => {
+        const prevKeys = Object.keys(state.callbacks)
+        const nextKeys = Object.keys(callbacks)
+        if (prevKeys.length !== nextKeys.length) {
+          state.callbacks = callbacks
+          return
+        }
         let changed = false
-        for (const key of Object.keys(callbacks) as Array<keyof MessageBlockCallbacks>) {
+        for (const key of nextKeys as Array<keyof MessageBlockCallbacks>) {
           if (state.callbacks[key] !== callbacks[key]) {
             changed = true
             break


### PR DESCRIPTION
# Add shallow equality guards to MessageBlockStore to prevent unnecessary renders

## Summary

• In `cli/src/state/message-block-store.ts`, added shallow equality guards to `setContext` and `setCallbacks` to prevent state reference churn and eliminate spurious notifications to store subscribers and context consumers.
• Previously, `setContext` (triggered on every layout effect in `<Chat />`) drafted and replaced `state.context` with a new object reference even when all property values were identical. Because Zustand notifies store subscribers whenever a new state reference is created by Immer, this triggered re-render passes for any components and listeners consuming the store or context directly.
• In `setContext`, added a key-by-key shallow equality guard for merged properties.
• In `setCallbacks`, respected full replacement semantics by checking key set length before checking individual values, ensuring that omitted callback keys trigger replacement rather than being silently preserved.
• Exported and shared a single `EMPTY_RESPONSE_ADS` module constant between `initialContext` and `chat.tsx`, ensuring stable object reference identity when ads are disabled with zero allocation.
• Added unit test suite in `cli/src/state/__tests__/message-block-store.test.ts` verifying that subscribers fire only on true mutations, are suppressed on identical updates, and handle omitted keys in `setCallbacks`.

## Test plan

[✓] `bun test --config=/dev/null src/state/__tests__/message-block-store.test.ts` — 4 pass, 0 fail
[✓] `bun run --cwd cli typecheck` — 0 errors
[✓] PR hygiene check passed
