### PR TITLE
Improve readability of count validation in lazy-response-ads

### DIFF
--- a/common/src/util/lazy-response-ads.ts
+++ b/common/src/util/lazy-response-ads.ts
@@ -58,9 +58,11 @@ export function requestLazyResponseAds<T extends { impUrl: string }>(params: {
   onAd: (ad: T) => void
 }): Promise<void> | null {
   const { queue, messageId, fetchOne, onAd } = params
-  const count = Number.isFinite(params.count)
-    ? Math.min(MAX_RESPONSE_AD_POOL_SIZE, Math.max(0, Math.floor(params.count)))
-    : 0
+  const safeCount = Number.isFinite(params.count) ? params.count : 0
+  const count = Math.min(
+    MAX_RESPONSE_AD_POOL_SIZE,
+    Math.max(0, Math.floor(safeCount)),
+  )
   const previousTarget = queue.targetCounts.get(messageId) ?? 0
   if (count <= previousTarget) return queue.inFlight.get(messageId) ?? null
 


### PR DESCRIPTION
## Overview
Improve code readability by extracting a complex ternary expression into a separate variable.

## Change
The original code had a nested ternary inside Math.min/Math.max:
```ts
const count = Number.isFinite(params.count)
  ? Math.min(MAX_RESPONSE_AD_POOL_SIZE, Math.max(0, Math.floor(params.count)))
  : 0
```

This was hard to read. Extracted the validation into a separate variable:
```ts
const safeCount = Number.isFinite(params.count) ? params.count : 0
const count = Math.min(MAX_RESPONSE_AD_POOL_SIZE, Math.max(0, Math.floor(safeCount)))
```

## Testing
All existing tests pass (5/5).

## Files Changed
- `common/src/util/lazy-response-ads.ts` - Refactored count validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.