### PR TITLE
Fix data URL validation in summarizeDataUrl

### DIFF
--- a/common/src/util/cache-debug.ts
+++ b/common/src/util/cache-debug.ts
@@ -53,7 +53,7 @@ function summarizeDataUrl(value: string): SerializableValue {
   const payload = firstComma >= 0 ? value.slice(firstComma + 1) : ''
   return {
     type: 'data-url',
-    mediaType: header.slice(5).split(';')[0] || 'unknown',
+    mediaType: header.startsWith('data:') ? header.slice(5).split(';')[0] || 'unknown' : 'unknown',
     payloadLength: payload.length,
     preview: payload.slice(0, 32),
   }


### PR DESCRIPTION
## Overview
Fix a potential bug in the `summarizeDataUrl` function in `common/src/util/cache-debug.ts`.

## Bug Description
The `summarizeDataUrl` function assumed the value started with `data:` (5 characters) and sliced from index 5 to extract the media type. If the value didn't start with `data:`, this would return incorrect results.

## Fix
Added a check to ensure the header starts with `data:` before slicing, returning `'unknown'` as the media type if it doesn't.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with malformed data URLs.

## Files Changed
- `common/src/util/cache-debug.ts` - Added data URL validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.