### PR TITLE
Fix escapeString to properly escape HTML-unsafe characters

### DIFF
--- a/common/src/util/string.ts
+++ b/common/src/util/string.ts
@@ -422,5 +422,10 @@ export function suffixPrefixOverlap(source: string, next: string): string {
 }
 
 export const escapeString = (str: string) => {
-  return JSON.stringify(str).slice(1, -1)
+  return JSON.stringify(str)
+    .slice(1, -1)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/'/g, '\\u0027')
 }


### PR DESCRIPTION
## Overview
Fix a potential XSS vulnerability in the `escapeString` function in `common/src/util/string.ts`.

## Bug Description
The `escapeString` function used `JSON.stringify` to escape a string, which handles quotes and backslashes but doesn't escape characters that are unsafe in HTML contexts: `<`, `>`, `&`, and `'`.

This is a security concern if the escaped string is used in HTML or XML contexts, as it could allow XSS attacks or HTML injection.

## Fix
Added explicit escaping for these characters to prevent potential security issues:
- `<` → `\\u003c`
- `>` → `\\u003e`
- `&` → `\\u0026`
- `'` → `\\u0027`

## Testing
No existing tests for this function, but the fix prevents potential XSS vulnerabilities.

## Files Changed
- `common/src/util/string.ts` - Added HTML-unsafe character escaping

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.