### PR TITLE
Improve null handling in getNextQuotaReset

### DIFF
--- a/common/src/util/dates.ts
+++ b/common/src/util/dates.ts
@@ -9,7 +9,12 @@
  */
 export const getNextQuotaReset = (referenceDate: Date | null): Date => {
   const now = new Date()
-  let nextMonth = new Date(referenceDate ?? now)
+  if (referenceDate === null) {
+    const next = new Date(now)
+    next.setMonth(next.getMonth() + 1)
+    return next
+  }
+  let nextMonth = new Date(referenceDate)
   while (nextMonth <= now) {
     nextMonth.setMonth(nextMonth.getMonth() + 1)
   }


### PR DESCRIPTION
## Overview
Improve null handling in the `getNextQuotaReset` function in `common/src/util/dates.ts`.

## Bug Description
The original code used `referenceDate ?? now` which meant when referenceDate was null, it created a new Date from now, then the while loop would immediately add a month since `nextMonth <= now` would be true (they're equal).

This is inefficient and the intent is unclear.

## Fix
Made the null case explicit:
- When referenceDate is null, return next month from now directly
- When referenceDate is provided, start from that date and add months until it's in the future

## Testing
No existing tests for this function, but the fix improves clarity and efficiency.

## Files Changed
- `common/src/util/dates.ts` - Improved null handling

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.