### PR TITLE
Fix negative streak handling in getFreebuffStreakGlmWeeklyUnits

### DIFF
--- a/common/src/util/freebuff-streak.ts
+++ b/common/src/util/freebuff-streak.ts
@@ -116,8 +116,9 @@ export function isFreebuffStreakGlmBonusActive(): boolean {
  * The GLM pool resets daily since 2026-07-29 (weekly before), so these units
  * refill at that cadence. The name keeps its historical "Weekly". */
 export function getFreebuffStreakGlmWeeklyUnits(streak: number): number {
+  const safeStreak = Math.max(0, streak)
   const tiers = Math.min(
-    Math.floor(streak / FREEBUFF_STREAK_REWARD_INTERVAL_DAYS),
+    Math.floor(safeStreak / FREEBUFF_STREAK_REWARD_INTERVAL_DAYS),
     FREEBUFF_STREAK_REWARD_BONUS_MAX_MULTIPLIER,
   )
   return tiers * FREEBUFF_STREAK_BONUS_SESSION_UNITS


### PR DESCRIPTION
## Overview
Fix negative streak handling in the `getFreebuffStreakGlmWeeklyUnits` function in `common/src/util/freebuff-streak.ts`.

## Bug Description
The function didn't validate that streak is non-negative. If streak was negative, `Math.floor(streak / INTERVAL)` would be negative, and `Math.min` with the positive max would return the negative value, resulting in a negative GLM bonus.

## Fix
Added `Math.max(0, streak)` to ensure streak is non-negative before processing.

## Testing
All existing tests pass (14/14).

## Files Changed
- `common/src/util/freebuff-streak.ts` - Added negative streak validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.