### PR TITLE
Use Number.isNaN instead of global isNaN for type safety

### DIFF
--- a/common/src/util/log-ingest.ts
+++ b/common/src/util/log-ingest.ts
@@ -72,7 +72,7 @@ export function buildLogRows(params: {
     }
     return {
       id: crypto.randomUUID(),
-      timestamp: isNaN(ts.getTime()) ? now : ts,
+      timestamp: Number.isNaN(ts.getTime()) ? now : ts,
       level: record.level,
       source,
       service,


### PR DESCRIPTION
## Overview
Fix type safety issue in `common/src/util/log-ingest.ts` by using `Number.isNaN` instead of the global `isNaN` function.

## Bug Description
The global `isNaN()` function coerces non-numbers to numbers first, which can lead to unexpected results. For example, `isNaN('hello')` returns `true` because `'hello'` is coerced to `NaN`, but `Number.isNaN('hello')` returns `false` because `'hello'` is not a number type.

## Fix
Changed `isNaN(ts.getTime())` to `Number.isNaN(ts.getTime())` for more predictable and safer type checking.

## Testing
No existing tests for this function, but the fix improves type safety.

## Files Changed
- `common/src/util/log-ingest.ts` - Use Number.isNaN instead of global isNaN

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.