### PR TITLE
Use Number.isNaN instead of global isNaN in saxy XML parser

### DIFF
--- a/common/src/util/saxy.ts
+++ b/common/src/util/saxy.ts
@@ -163,7 +163,7 @@ const parseEntities = (input: string): string => {
         value = parseInt(entityName.slice(1), 10)
       }
 
-      if (isNaN(value)) {
+      if (Number.isNaN(value)) {
         parts.push('&' + entityName + ';')
       } else {
         parts.push(String.fromCharCode(value))


### PR DESCRIPTION
## Overview
Fix type safety issue in `common/src/util/saxy.ts` by using `Number.isNaN` instead of the global `isNaN` function.

## Bug Description
The global `isNaN()` function coerces non-numbers to numbers first, which can lead to unexpected results.

## Fix
Changed `isNaN(value)` to `Number.isNaN(value)` for more predictable and safer type checking.

## Testing
No existing tests for this function, but the fix improves type safety.

## Files Changed
- `common/src/util/saxy.ts` - Use Number.isNaN instead of global isNaN

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.