### PR TITLE
Use Number.isNaN instead of global isNaN in dates utility

### DIFF
--- a/common/src/util/dates.ts
+++ b/common/src/util/dates.ts
@@ -59,7 +59,7 @@ export const formatTimeUntil = (
   const target = typeof date === 'string' ? new Date(date) : date
   const diffMs = target.getTime() - Date.now()
 
-  if (isNaN(diffMs) || diffMs <= 0) return fallback
+  if (Number.isNaN(diffMs) || diffMs <= 0) return fallback
 
   const diffMins = Math.floor(diffMs / (1000 * 60))
   const diffHours = Math.floor(diffMins / 60)


### PR DESCRIPTION
## Overview
Fix type safety issue in `common/src/util/dates.ts` by using `Number.isNaN` instead of the global `isNaN` function.

## Bug Description
The global `isNaN()` function coerces non-numbers to numbers first, which can lead to unexpected results.

## Fix
Changed `isNaN(diffMs)` to `Number.isNaN(diffMs)` for more predictable and safer type checking.

## Testing
No existing tests for this function, but the fix improves type safety.

## Files Changed
- `common/src/util/dates.ts` - Use Number.isNaN instead of global isNaN

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.