### PR TITLE
Fix NaN/Infinity handling in responseAdDisplayCount

### DIFF
--- a/common/src/util/lazy-response-ads.ts
+++ b/common/src/util/lazy-response-ads.ts
@@ -16,8 +16,10 @@ export function responseAdDisplayCount(params: {
   eligibleCount: number
   poolSize: number
 }): number {
-  const eligibleCount = Math.max(0, Math.floor(params.eligibleCount))
-  const poolSize = Math.max(0, Math.floor(params.poolSize))
+  const safeEligibleCount = Number.isFinite(params.eligibleCount) ? params.eligibleCount : 0
+  const safePoolSize = Number.isFinite(params.poolSize) ? params.poolSize : 0
+  const eligibleCount = Math.max(0, Math.floor(safeEligibleCount))
+  const poolSize = Math.max(0, Math.floor(safePoolSize))
   return poolSize >= MAX_RESPONSE_AD_POOL_SIZE
     ? eligibleCount
     : Math.min(eligibleCount, poolSize)


### PR DESCRIPTION
## Overview
Fix NaN/Infinity handling in the `responseAdDisplayCount` function in `common/src/util/lazy-response-ads.ts`.

## Bug Description
The function used `Math.floor()` without checking if the input was a valid number. If `params.eligibleCount` or `params.poolSize` was NaN or Infinity, `Math.floor()` would return NaN, and `Math.max(0, NaN)` would return NaN, causing incorrect results.

## Fix
Added `Number.isFinite()` checks to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/lazy-response-ads.ts` - Added NaN/Infinity validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.