### PR TITLE
Fix NaN handling in ttftBucketIndex

### DIFF
--- a/common/src/util/ttft-histogram.ts
+++ b/common/src/util/ttft-histogram.ts
@@ -37,7 +37,8 @@ const LN_BASE = Math.log(TTFT_HISTOGRAM_BASE)
  * Sub-millisecond and zero samples land in bucket 0 rather than at -Infinity.
  */
 export function ttftBucketIndex(ttftMs: number): number {
-  const index = Math.floor(Math.log(Math.max(ttftMs, 1)) / LN_BASE)
+  const safeTtftMs = Number.isFinite(ttftMs) ? ttftMs : 0
+  const index = Math.floor(Math.log(Math.max(safeTtftMs, 1)) / LN_BASE)
   return Math.min(TTFT_HISTOGRAM_BUCKET_COUNT - 1, Math.max(0, index))
 }
 


### PR DESCRIPTION
## Overview
Fix NaN handling in the `ttftBucketIndex` function in `common/src/util/ttft-histogram.ts`.

## Bug Description
The function didn't validate that ttftMs is a finite number. If ttftMs was NaN or Infinity, `Math.max(NaN, 1)` would return NaN, causing `Math.log(NaN)` to return NaN, and the entire calculation would produce NaN.

## Fix
Added `Number.isFinite()` check to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/ttft-histogram.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.