### PR TITLE
Fix NaN handling in file read limits

### DIFF
--- a/common/src/util/file-read-limits.ts
+++ b/common/src/util/file-read-limits.ts
@@ -170,10 +170,12 @@ function limitFileReadContent(
   remainingTokens: number,
   countTokens?: (text: string) => number,
 ): LimitedFileRead {
-  const charLimit = Math.min(content.length, Math.max(0, remainingChars))
+  const safeRemainingChars = Number.isFinite(remainingChars) ? remainingChars : 0
+  const charLimit = Math.min(content.length, Math.max(0, safeRemainingChars))
   const safeCharLimit = avoidSplittingSurrogatePair(content, charLimit)
   const charLimitedContent = content.slice(0, safeCharLimit)
-  const tokenBudget = Math.max(0, remainingTokens)
+  const safeRemainingTokens = Number.isFinite(remainingTokens) ? remainingTokens : 0
+  const tokenBudget = Math.max(0, safeRemainingTokens)
   const tokenLimit = countTokens
     ? limitContentByTokens(charLimitedContent, tokenBudget, countTokens)
     : {


### PR DESCRIPTION
## Overview
Fix NaN handling in file read limits in `common/src/util/file-read-limits.ts`.

## Bug Description
The function didn't validate that remainingChars and remainingTokens are finite numbers. If they were NaN or Infinity, `Math.max(0, NaN)` would return NaN, causing incorrect calculations.

## Fix
Added `Number.isFinite()` checks to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/file-read-limits.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.