### PR TITLE
Fix NaN handling in pct function in db-health-alerts

### DIFF
--- a/common/src/util/db-health-alerts.ts
+++ b/common/src/util/db-health-alerts.ts
@@ -292,8 +292,10 @@ export function evaluateStatCoverage(row: StatCoverageRow): StatCoverage {
   // may break the alert that does not consult it.
   const statementsBlind = statementRows === 0
   const activityBlind = activityVisible === 0
-  const pct = (part: number, whole: number) =>
-    whole > 0 ? Math.round((part / whole) * 100) : 0
+  const pct = (part: number, whole: number) => {
+    if (!Number.isFinite(part) || !Number.isFinite(whole) || whole <= 0) return 0
+    return Math.round((part / whole) * 100)
+  }
   const summary = row.has_read_all_stats
     ? `role ${row.role} has pg_read_all_stats: full fleet visibility`
     : `role ${row.role} lacks pg_read_all_stats — ${statementsWithText}/${statementRows} ` +


### PR DESCRIPTION
## Overview
Fix NaN handling in the `pct` function in `common/src/util/db-health-alerts.ts`.

## Bug Description
The function didn't validate that part and whole are finite numbers. If either was NaN or Infinity, `Math.round((part / whole) * 100)` would return NaN.

## Fix
Added `Number.isFinite()` checks to return 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/db-health-alerts.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.