### PR TITLE
Fix NaN handling in formatPlanUnits

### DIFF
--- a/common/src/util/freebuff-plan-summary.ts
+++ b/common/src/util/freebuff-plan-summary.ts
@@ -40,6 +40,7 @@ export interface FreebuffPlanSummary {
 
 /** Session units, without trailing ".0" noise: 2, 0.5, 1.5. */
 export function formatPlanUnits(units: number): string {
+  if (!Number.isFinite(units)) return '0'
   const rounded = Math.round(units * 10) / 10
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
 }


### PR DESCRIPTION
## Overview
Fix NaN handling in the `formatPlanUnits` function in `common/src/util/freebuff-plan-summary.ts`.

## Bug Description
The function didn't validate that units is a finite number. If units was NaN or Infinity, `Math.round(units * 10) / 10` would return NaN, causing the function to return 'NaN' as a string.

## Fix
Added `Number.isFinite()` check to return '0' for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/freebuff-plan-summary.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.