### PR TITLE
Fix NaN handling in windowFileRead offset and limit

### DIFF
--- a/common/src/util/file-read-limits.ts
+++ b/common/src/util/file-read-limits.ts
@@ -22,9 +22,11 @@ export function windowFileRead(
   const lines = content.split('\n')
   if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop()
   const totalLines = lines.length
-  const start = Math.max(1, Math.floor(offset ?? 1))
+  const safeOffset = offset !== undefined && Number.isFinite(offset) ? offset : 1
+  const safeLimit = limit !== undefined && Number.isFinite(limit) ? limit : MAX_READ_FILE_LINES
+  const start = Math.max(1, Math.floor(safeOffset))
   const maxLines = Math.min(
-    Math.max(1, Math.floor(limit ?? MAX_READ_FILE_LINES)),
+    Math.max(1, Math.floor(safeLimit)),
     MAX_READ_FILE_LINES,
   )
 


### PR DESCRIPTION
## Overview
Fix NaN handling in the `windowFileRead` function in `common/src/util/file-read-limits.ts`.

## Bug Description
The function didn't validate that offset and limit are finite numbers. If they were NaN or Infinity, `Math.floor(NaN ?? 1)` would return NaN, causing `Math.max(1, NaN)` to return NaN.

## Fix
Added `Number.isFinite()` checks to default to safe values for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/file-read-limits.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.