### PR TITLE
Fix NaN handling in getResponseAdForSlot

### DIFF
--- a/common/src/util/lazy-response-ads.ts
+++ b/common/src/util/lazy-response-ads.ts
@@ -29,7 +29,8 @@ export function getResponseAdForSlot<T>(
   slotIndex: number,
 ): T | undefined {
   if (ads.length === 0) return undefined
-  return ads[Math.max(0, Math.floor(slotIndex)) % ads.length]
+  const safeSlotIndex = Number.isFinite(slotIndex) ? slotIndex : 0
+  return ads[Math.max(0, Math.floor(safeSlotIndex)) % ads.length]
 }
 
 export function createLazyResponseAdQueue<


### PR DESCRIPTION
## Overview
Fix NaN handling in the `getResponseAdForSlot` function in `common/src/util/lazy-response-ads.ts`.

## Bug Description
The function didn't validate that slotIndex is a finite number. If slotIndex was NaN or Infinity, `Math.floor(NaN)` would return NaN, causing `Math.max(0, NaN)` to return NaN, and `NaN % ads.length` to return NaN.

## Fix
Added `Number.isFinite()` check to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/lazy-response-ads.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.