### PR TITLE
Fix Infinity validation in daysBetween

### DIFF
--- a/common/src/util/reddit-freebuff-retention.ts
+++ b/common/src/util/reddit-freebuff-retention.ts
@@ -14,7 +14,7 @@ export type FreebuffRedditConversionPlan = {
 function daysBetween(fromDateKey: string, toDateKey: string): number {
   const from = new Date(`${fromDateKey}T00:00:00.000Z`).getTime()
   const to = new Date(`${toDateKey}T00:00:00.000Z`).getTime()
-  if (Number.isNaN(from) || Number.isNaN(to)) {
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
     throw new Error(`Invalid date key range: ${fromDateKey} -> ${toDateKey}`)
   }
   return Math.round((to - from) / DAY_MS)


### PR DESCRIPTION
## Overview
Fix Infinity validation in the `daysBetween` function in `common/src/util/reddit-freebuff-retention.ts`.

## Bug Description
The function only checked for NaN, not Infinity. If the date string represented an extreme date, `getTime()` could return Infinity, causing `Math.round(Infinity)` to return Infinity.

## Fix
Changed `Number.isNaN()` to `Number.isFinite()` to catch both NaN and Infinity.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with extreme dates.

## Files Changed
- `common/src/util/reddit-freebuff-retention.ts` - Added Infinity validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.