### PR TITLE
Fix NaN handling in build seconds calculation

### DIFF
--- a/common/src/util/db-health-alerts.ts
+++ b/common/src/util/db-health-alerts.ts
@@ -380,8 +380,9 @@ export function evaluateInvalidIndexes(
     const stuck =
       building && buildSeconds !== null && buildSeconds >= stuckMinutes * 60
     if (!building || stuck) {
+      const safeBuildSeconds = buildSeconds !== null && Number.isFinite(buildSeconds) ? buildSeconds : 0
       const where = building
-        ? `building ${Math.round((buildSeconds ?? 0) / 60)}m`
+        ? `building ${Math.round(safeBuildSeconds / 60)}m`
         : 'not building'
       offenders.push(
         `${row.schema}.${row.table_name}.${row.index_name} (${where}, indisready=${row.indisready})`,


### PR DESCRIPTION
## Overview
Fix NaN handling in build seconds calculation in `common/src/util/db-health-alerts.ts`.

## Bug Description
The code didn't validate that buildSeconds is a finite number. If buildSeconds was NaN or Infinity, `Math.round(NaN / 60)` would return NaN.

## Fix
Added `Number.isFinite()` check to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/db-health-alerts.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.