### PR TITLE
Fix Infinity overflow in retry backoff calculation

### DIFF
--- a/common/src/util/promise.ts
+++ b/common/src/util/promise.ts
@@ -32,8 +32,9 @@ export async function withRetry<T>(
 
       // Exponential backoff with jitter (±20%) to prevent thundering herd
       const baseDelayMs = retryDelayMs * Math.pow(2, attempt)
+      const safeBaseDelayMs = Number.isFinite(baseDelayMs) ? baseDelayMs : Number.MAX_SAFE_INTEGER
       const jitter = 0.8 + Math.random() * 0.4 // Random multiplier between 0.8 and 1.2
-      const delayMs = Math.round(baseDelayMs * jitter)
+      const delayMs = Math.round(safeBaseDelayMs * jitter)
       await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
   }


### PR DESCRIPTION
## Overview
Fix Infinity overflow in retry backoff calculation in `common/src/util/promise.ts`.

## Bug Description
The function used `Math.pow(2, attempt)` which can overflow to Infinity if attempt is large. Then `Math.round(Infinity * jitter)` returns Infinity, and `setTimeout` with Infinity would never fire, causing the retry to hang forever.

## Fix
Added `Number.isFinite()` check to cap the delay at `Number.MAX_SAFE_INTEGER`.

## Testing
No existing tests for this function, but the fix prevents infinite hangs.

## Files Changed
- `common/src/util/promise.ts` - Added overflow protection

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.