### PR TITLE
Fix NaN handling in formatFreebuffRowQuota

### DIFF
--- a/common/src/util/freebuff-session-pools.ts
+++ b/common/src/util/freebuff-session-pools.ts
@@ -87,7 +87,9 @@ export function getFreebuffSectionQuotas(
 export function formatFreebuffRowQuota(
   quota: FreebuffSessionRateLimit,
 ): string {
-  const used = Math.min(quota.recentCount, quota.limit)
-  const count = `${used} of ${quota.limit} ${quota.countsAdmissions ? 'starts' : 'used'}`
+  const safeRecentCount = Number.isFinite(quota.recentCount) ? quota.recentCount : 0
+  const safeLimit = Number.isFinite(quota.limit) ? quota.limit : 0
+  const used = Math.min(safeRecentCount, safeLimit)
+  const count = `${used} of ${safeLimit} ${quota.countsAdmissions ? 'starts' : 'used'}`
   return quota.poolLabel ? `${quota.poolLabel}: ${count}` : count
 }


### PR DESCRIPTION
## Overview
Fix NaN handling in the `formatFreebuffRowQuota` function in `common/src/util/freebuff-session-pools.ts`.

## Bug Description
The function didn't validate that recentCount and limit are finite numbers. If either was NaN or Infinity, `Math.min(NaN, NaN)` would return NaN, causing the function to return 'NaN of NaN' as a string.

## Fix
Added `Number.isFinite()` checks to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/freebuff-session-pools.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.