### PR TITLE
Fix NaN handling in getFreebuffStreakLine

### DIFF
--- a/common/src/util/freebuff-streak-line.ts
+++ b/common/src/util/freebuff-streak-line.ts
@@ -47,8 +47,9 @@ export function getFreebuffStreakLine(
   // Fill toward the 7-day milestone, then stay full — a 19-day streak should
   // read as fully earned, not roll back over into a partial second week. Past
   // the week, a trailing "+" marks that the streak has run beyond the row.
-  const filled = Math.min(streak, FREEBUFF_STREAK_WEEK)
-  const beyond = streak > FREEBUFF_STREAK_WEEK
+  const safeStreak = Number.isFinite(streak) ? streak : 0
+  const filled = Math.min(safeStreak, FREEBUFF_STREAK_WEEK)
+  const beyond = safeStreak > FREEBUFF_STREAK_WEEK
   const dots =
     chars.filled.repeat(filled) +
     chars.empty.repeat(FREEBUFF_STREAK_WEEK - filled) +
@@ -57,7 +58,7 @@ export function getFreebuffStreakLine(
   // "day" stays singular — it's a compound modifier ("7 day streak"), not a
   // count of days on its own.
   return {
-    label: `${streak} day streak`,
+    label: `${safeStreak} day streak`,
     dots,
     progress: { filled, total: FREEBUFF_STREAK_WEEK, beyond },
   }


### PR DESCRIPTION
## Overview
Fix NaN handling in the `getFreebuffStreakLine` function in `common/src/util/freebuff-streak-line.ts`.

## Bug Description
The function didn't validate that streak is a finite number. If streak was NaN or Infinity, `Math.min(NaN, 7)` would return NaN, and `chars.filled.repeat(NaN)` would throw a RangeError.

## Fix
Added `Number.isFinite()` check to default to 0 for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents runtime errors with invalid inputs.

## Files Changed
- `common/src/util/freebuff-streak-line.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.