### PR TITLE
Fix size validation in sampleSizeWithSeed

### DIFF
--- a/common/src/util/random.ts
+++ b/common/src/util/random.ts
@@ -5,11 +5,12 @@ export function sampleSizeWithSeed<T>(
   size: number,
   seed: string,
 ): T[] {
+  const safeSize = Number.isFinite(size) && size >= 0 ? Math.floor(size) : 0
   const rng = seedrandom(seed)
   const result = array.slice()
   for (let i = result.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1))
     ;[result[i], result[j]] = [result[j], result[i]]
   }
-  return result.slice(0, size)
+  return result.slice(0, safeSize)
 }


### PR DESCRIPTION
## Overview
Fix size validation in the `sampleSizeWithSeed` function in `common/src/util/random.ts`.

## Bug Description
The function didn't validate that size is a non-negative integer. If size was NaN, negative, or not an integer, `result.slice(0, size)` could behave unexpectedly.

## Fix
Added `Number.isFinite()` and `size >= 0` checks to default to 0 for invalid sizes.

## Testing
No existing tests for this function, but the fix prevents unexpected behavior with invalid inputs.

## Files Changed
- `common/src/util/random.ts` - Added size validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.