### PR TITLE
Fix NaN handling in currency conversion input validation

### DIFF
--- a/common/src/util/currency.ts
+++ b/common/src/util/currency.ts
@@ -8,6 +8,8 @@ export function convertCreditsToUsdCents(
   credits: number,
   centsPerCredit: number,
 ): number {
+  if (centsPerCredit <= 0) return 0
+  if (!Number.isFinite(credits)) return 0
   return Math.ceil(credits * centsPerCredit)
 }
 
@@ -21,5 +23,7 @@ export function convertStripeGrantAmountToCredits(
   amountInCents: number,
   centsPerCredit: number,
 ): number {
+  if (centsPerCredit <= 0) return 0
+  if (!Number.isFinite(amountInCents)) return 0
   return Math.floor(amountInCents / centsPerCredit)
 }


### PR DESCRIPTION
## Overview
Fix NaN handling in currency conversion input validation in `common/src/util/currency.ts`.

## Bug Description
The functions didn't validate that credits and amountInCents are finite numbers. If they were NaN or Infinity, `Math.ceil(NaN * centsPerCredit)` would return NaN.

## Fix
Added `Number.isFinite()` checks to return 0 for invalid inputs.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/currency.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.