### PR TITLE
Fix Infinity validation in addDaysToDateKey

### DIFF
--- a/common/src/util/freebuff-streak.ts
+++ b/common/src/util/freebuff-streak.ts
@@ -48,7 +48,7 @@ export function getFreebuffUsageDateKey(
 
 export function addDaysToDateKey(dateKey: string, days: number): string {
   const date = new Date(`${dateKey}T00:00:00.000Z`)
-  if (Number.isNaN(date.getTime())) {
+  if (!Number.isFinite(date.getTime())) {
     throw new Error(`Invalid date key: ${dateKey}`)
   }
 


### PR DESCRIPTION
## Overview
Fix Infinity validation in the `addDaysToDateKey` function in `common/src/util/freebuff-streak.ts`.

## Bug Description
The function only checked for NaN, not Infinity. If the date string represented an extreme date, `getTime()` could return Infinity, causing the date arithmetic to produce invalid results.

## Fix
Changed `Number.isNaN()` to `Number.isFinite()` to catch both NaN and Infinity.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with extreme dates.

## Files Changed
- `common/src/util/freebuff-streak.ts` - Added Infinity validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.