### PR TITLE
Fix NaN handling in windowDays calculation

### DIFF
--- a/common/src/util/freebuff-usage-summary.ts
+++ b/common/src/util/freebuff-usage-summary.ts
@@ -53,7 +53,8 @@ export function buildFreebuffUsageSummary(params: {
   windowDays?: number
   timeZone?: string
 }): FreebuffUsageSummary {
-  const windowDays = Math.max(1, params.windowDays ?? FREEBUFF_USAGE_MAP_DAYS)
+  const safeWindowDays = params.windowDays !== undefined && Number.isFinite(params.windowDays) ? params.windowDays : FREEBUFF_USAGE_MAP_DAYS
+  const windowDays = Math.max(1, safeWindowDays)
   const todayDateKey = params.todayDateKey
 
   const allDates = [...new Set(params.activeDates)]


### PR DESCRIPTION
## Overview
Fix NaN handling in windowDays calculation in `common/src/util/freebuff-usage-summary.ts`.

## Bug Description
The function didn't validate that params.windowDays is a finite number. If it was NaN or Infinity, `Math.max(1, NaN)` would return NaN.

## Fix
Added `Number.isFinite()` check to default to `FREEBUFF_USAGE_MAP_DAYS` for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/freebuff-usage-summary.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.