### PR TITLE
Fix NaN handling in responseAdSlotCount

### DIFF
--- a/common/src/util/response-ad-positions.ts
+++ b/common/src/util/response-ad-positions.ts
@@ -18,11 +18,10 @@ export function responseAdSlotCount(params: {
   step?: number
   firstAdAfterNodes?: number
 }): number {
-  const step = Math.max(1, params.step ?? RESPONSE_AD_NODE_STEP)
-  const firstAdAfterNodes = Math.max(
-    1,
-    params.firstAdAfterNodes ?? RESPONSE_AD_FIRST_NODE_COUNT,
-  )
+  const safeStep = params.step !== undefined && Number.isFinite(params.step) ? params.step : RESPONSE_AD_NODE_STEP
+  const safeFirstAdAfterNodes = params.firstAdAfterNodes !== undefined && Number.isFinite(params.firstAdAfterNodes) ? params.firstAdAfterNodes : RESPONSE_AD_FIRST_NODE_COUNT
+  const step = Math.max(1, safeStep)
+  const firstAdAfterNodes = Math.max(1, safeFirstAdAfterNodes)
   return Math.max(
     0,
     Math.floor((params.nodeCount - firstAdAfterNodes - 1) / step) + 1,


### PR DESCRIPTION
## Overview
Fix NaN handling in the `responseAdSlotCount` function in `common/src/util/response-ad-positions.ts`.

## Bug Description
The function didn't validate that params.step and params.firstAdAfterNodes are finite numbers. If they were NaN or Infinity, `Math.max(1, NaN)` would return NaN.

## Fix
Added `Number.isFinite()` checks to default to safe values for invalid numbers.

## Testing
No existing tests for this function, but the fix prevents incorrect behavior with invalid inputs.

## Files Changed
- `common/src/util/response-ad-positions.ts` - Added NaN validation

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.