### PR TITLE
fix: add linux-x64-baseline and win32-x64-baseline target mappings to build script

### DIFF
--- a/cli/scripts/build-binary.ts
+++ b/cli/scripts/build-binary.ts
@@ -81,6 +81,11 @@ function getTargetInfo(): TargetInfo {
 
   const mappings: Record<string, TargetInfo> = {
     'linux-x64': { bunTarget: 'bun-linux-x64', platform: 'linux', arch: 'x64' },
+    'linux-x64-baseline': {
+      bunTarget: 'bun-linux-x64-baseline',
+      platform: 'linux',
+      arch: 'x64',
+    },
     'linux-arm64': {
       bunTarget: 'bun-linux-arm64',
       platform: 'linux',
@@ -98,6 +103,11 @@ function getTargetInfo(): TargetInfo {
     },
     'win32-x64': {
       bunTarget: 'bun-windows-x64',
+      platform: 'win32',
+      arch: 'x64',
+    },
+    'win32-x64-baseline': {
+      bunTarget: 'bun-windows-x64-baseline',
       platform: 'win32',
       arch: 'x64',
     },


### PR DESCRIPTION
Re-opening PR #814 following the repository history rewrite, as requested by maintainers.

### Summary
Adds the missing `'linux-x64-baseline'` and `'win32-x64-baseline'` target mappings to `cli/scripts/build-binary.ts`. This allows the build pipeline to properly resolve and output baseline binaries for older x86-64 CPUs on both Linux and Windows.

### Details & Verification
- **Target Mappings:** Adds both `'linux-x64-baseline'` (mapping to `'bun-linux-x64-baseline'`) and `'win32-x64-baseline'` (mapping to `'bun-windows-x64-baseline'`) under `getTargetInfo()`.
- **Bun Compatibility:** Per [Bun's Executables Documentation](https://bun.sh/docs/bundler/executables), `bun-linux-x64-baseline` and `bun-windows-x64-baseline` are valid compile targets (accepted for backward compatibility and mapped to x64 Nehalem/SSE4.2 baseline targets).
- **Client Fallback:** The CLI client runtime (`index.js`) already expects `freebuff-linux-x64-baseline.tar.gz` and `freebuff-win32-x64-baseline.tar.gz` artifacts when fallback triggers or `FREEBUFF_BINARY_TARGET` is set. Without these mappings in `build-binary.ts`, `getTargetInfo()` throws an unsupported target error during the build phase.

### Related Context & Issues
- Fixes #797 (AVX/SIGILL issue on older CPUs)
- Ref PR #814 (Prior PR auto-closed due to repo history rewrite)
- Ref PR #802 (Docs PR linking the baseline troubleshooting)