### PR TITLE
Optimize calculateFreebuffStreak to single-pass iteration

### DIFF
--- a/common/src/util/freebuff-streak.ts
+++ b/common/src/util/freebuff-streak.ts
@@ -64,13 +64,15 @@ export function calculateFreebuffStreak(params: {
   lastUsageDate: string | null
 } {
   const { usageDates, todayDateKey } = params
-  const usageDateSet = new Set(
-    usageDates.filter((date) => date <= todayDateKey),
-  )
-  const lastUsageDate = usageDates.reduce<string | null>((latest, date) => {
-    if (date > todayDateKey) return latest
-    return latest === null || date > latest ? date : latest
-  }, null)
+  const usageDateSet = new Set<string>()
+  let lastUsageDate: string | null = null
+  for (const date of usageDates) {
+    if (date > todayDateKey) continue
+    usageDateSet.add(date)
+    if (lastUsageDate === null || date > lastUsageDate) {
+      lastUsageDate = date
+    }
+  }
   const todayUsed = usageDateSet.has(todayDateKey)
 
   let anchorDateKey = todayDateKey


### PR DESCRIPTION
## Overview
Optimize the `calculateFreebuffStreak` function in `common/src/util/freebuff-streak.ts` to use a single pass instead of two iterations.

## Bug Description
The function iterated through `usageDates` twice:
1. Once with `filter()` to build the `usageDateSet`
2. Once with `reduce()` to find `lastUsageDate`

This is O(2n) when it could be O(n) by combining both operations in a single loop.

## Fix
Combined both operations into one loop, building the set and tracking the latest date simultaneously. This is more efficient and clearer in intent.

## Testing
All existing tests pass (14/14).

## Files Changed
- `common/src/util/freebuff-streak.ts` - Single-pass iteration optimization

## Scope
This change only touches `common/src/util/freebuff-streak.ts` (a single file in the approved `common/` area).