### PR TITLE
Fix negative streak handling in getFreebuffStreakGlmWeeklyUnits

### DIFF
--- a/common/src/util/__tests__/freebuff-streak.test.ts
+++ b/common/src/util/__tests__/freebuff-streak.test.ts
@@ -5,6 +5,7 @@ import {
   calculateFreebuffStreak,
   getFreebuffDailyStreakRewardPool,
   getFreebuffStreakGlmBonusUnits,
+  getFreebuffStreakGlmWeeklyUnits,
   getFreebuffUsageDateKey,
 } from '../freebuff-streak'
 
@@ -198,5 +199,15 @@ describe('freebuff streak rewards', () => {
         accessTier: 'full',
       }),
     ).toBeNull()
+  })
+
+  test('getFreebuffStreakGlmWeeklyUnits clamps negative streaks to zero', () => {
+    // Negative streak values would produce negative bonus units without the clamp.
+    expect(getFreebuffStreakGlmWeeklyUnits(-1)).toBe(0)
+    expect(getFreebuffStreakGlmWeeklyUnits(-100)).toBe(0)
+    // Zero and positive values work as before.
+    expect(getFreebuffStreakGlmWeeklyUnits(0)).toBe(0)
+    expect(getFreebuffStreakGlmWeeklyUnits(7)).toBe(1)
+    expect(getFreebuffStreakGlmWeeklyUnits(14)).toBe(2)
   })
 })

--- a/common/src/util/freebuff-streak.ts
+++ b/common/src/util/freebuff-streak.ts
@@ -116,8 +116,9 @@ export function isFreebuffStreakGlmBonusActive(): boolean {
  * The GLM pool resets daily since 2026-07-29 (weekly before), so these units
  * refill at that cadence. The name keeps its historical "Weekly". */
 export function getFreebuffStreakGlmWeeklyUnits(streak: number): number {
+  const safeStreak = Math.max(0, streak)
   const tiers = Math.min(
-    Math.floor(streak / FREEBUFF_STREAK_REWARD_INTERVAL_DAYS),
+    Math.floor(safeStreak / FREEBUFF_STREAK_REWARD_INTERVAL_DAYS),
     FREEBUFF_STREAK_REWARD_BONUS_MAX_MULTIPLIER,
   )
   return tiers * FREEBUFF_STREAK_BONUS_SESSION_UNITS


### PR DESCRIPTION
## Overview
Fix negative streak handling in the `getFreebuffStreakGlmWeeklyUnits` function in `common/src/util/freebuff-streak.ts`.

## Bug Description
The function didn't validate that streak is non-negative. If streak was negative, `Math.floor(streak / INTERVAL)` would be negative, and `Math.min` with the positive max would return the negative value, resulting in a negative GLM bonus.

## Fix
Added `Math.max(0, streak)` to ensure streak is non-negative before processing.

## Testing
Added a new test case that verifies:
- Negative streak values (-1, -100) return 0
- Zero streak returns 0
- Positive streaks work as expected (7 → 1, 14 → 2)

All 15 tests pass (including the new one).

## Files Changed
- `common/src/util/freebuff-streak.ts` - Added negative streak validation
- `common/src/util/__tests__/freebuff-streak.test.ts` - Added test coverage

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.