### PR TITLE
Add defensive check for data URL prefix in summarizeDataUrl

### DIFF
--- a/common/src/util/__tests__/cache-debug.test.ts
+++ b/common/src/util/__tests__/cache-debug.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test'
+
+import { normalizeProviderRequestBodyForCacheDebug } from '../cache-debug'
+
+describe('cache-debug data URL handling', () => {
+  it('summarizes valid data URLs', () => {
+    const result = normalizeProviderRequestBodyForCacheDebug({
+      provider: 'openai',
+      body: {
+        model: 'gpt-4',
+        messages: [
+          {
+            role: 'user',
+            content: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+          },
+        ],
+      },
+    })
+
+    const message = (result as { messages: unknown[] }).messages[0] as {
+      content: { type: string; mediaType: string; payloadLength: number }
+    }
+    expect(message.content.type).toBe('data-url')
+    expect(message.content.mediaType).toBe('image/png')
+    expect(message.content.payloadLength).toBeGreaterThan(0)
+  })
+
+  it('passes through non-data-URL strings unchanged', () => {
+    const result = normalizeProviderRequestBodyForCacheDebug({
+      provider: 'openai',
+      body: {
+        model: 'gpt-4',
+        messages: [
+          {
+            role: 'user',
+            content: 'https://example.com/image.png',
+          },
+        ],
+      },
+    })
+
+    const message = (result as { messages: unknown[] }).messages[0] as {
+      content: string
+    }
+    expect(message.content).toBe('https://example.com/image.png')
+  })
+
+  it('handles data URL-like strings without comma gracefully', () => {
+    // Edge case: string starts with "data:" but has no comma
+    const result = normalizeProviderRequestBodyForCacheDebug({
+      provider: 'openai',
+      body: {
+        model: 'gpt-4',
+        messages: [
+          {
+            role: 'user',
+            content: 'data:image/png;base64',
+          },
+        ],
+      },
+    })
+
+    const message = (result as { messages: unknown[] }).messages[0] as {
+      content: { type: string; mediaType: string; payloadLength: number }
+    }
+    expect(message.content.type).toBe('data-url')
+    expect(message.content.mediaType).toBe('image/png')
+    expect(message.content.payloadLength).toBe(0)
+  })
+})

--- a/common/src/util/cache-debug.ts
+++ b/common/src/util/cache-debug.ts
@@ -48,6 +48,9 @@ function normalizeForJson(value: unknown): SerializableValue {
 }
 
 function summarizeDataUrl(value: string): SerializableValue {
+  if (!value.startsWith('data:')) {
+    return value
+  }
   const firstComma = value.indexOf(',')
   const header = firstComma >= 0 ? value.slice(0, firstComma) : value
   const payload = firstComma >= 0 ? value.slice(firstComma + 1) : ''


### PR DESCRIPTION
## Overview
Add a defensive check for the data URL prefix in `summarizeDataUrl` function in `common/src/util/cache-debug.ts`.

## Bug Description
The `summarizeDataUrl` function was called from `summarizeLargeValue` which checks if a string starts with `data:` before calling it. However, if `summarizeDataUrl` were ever called from a different context or if the prefix check were removed, the function would incorrectly try to parse non-data-URL strings, potentially producing misleading summaries.

## Fix
Added a defensive check at the start of `summarizeDataUrl` that returns the value unchanged if it doesn't start with `data:`. This makes the function safer to use independently and prevents incorrect parsing of malformed inputs.

## Testing
Added comprehensive test coverage demonstrating:
1. Valid data URLs are properly summarized (image/png with base64 payload)
2. Non-data-URL strings (https://example.com/image.png) pass through unchanged
3. Edge case: data URL-like strings without comma are handled gracefully

All 3 tests pass.

## Files Changed
- `common/src/util/cache-debug.ts` - Added defensive prefix check
- `common/src/util/__tests__/cache-debug.test.ts` - New test file with 3 test cases

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.