### PR TITLE
Fix NaN/Infinity handling in responseAdDisplayCount with tests

### DIFF
--- a/common/src/util/__tests__/lazy-response-ads.test.ts
+++ b/common/src/util/__tests__/lazy-response-ads.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+
+import { responseAdDisplayCount } from '../lazy-response-ads'
+
+describe('responseAdDisplayCount', () => {
+  it('returns eligibleCount when poolSize is at or above the max', () => {
+    expect(
+      responseAdDisplayCount({ eligibleCount: 5, poolSize: 100 }),
+    ).toBe(5)
+  })
+
+  it('clamps to poolSize when poolSize is below the max', () => {
+    expect(responseAdDisplayCount({ eligibleCount: 10, poolSize: 3 })).toBe(3)
+  })
+
+  it('returns 0 when eligibleCount is NaN', () => {
+    expect(responseAdDisplayCount({ eligibleCount: NaN, poolSize: 10 })).toBe(0)
+  })
+
+  it('returns 0 when poolSize is NaN', () => {
+    expect(responseAdDisplayCount({ eligibleCount: 5, poolSize: NaN })).toBe(0)
+  })
+
+  it('returns 0 when eligibleCount is Infinity', () => {
+    expect(
+      responseAdDisplayCount({ eligibleCount: Infinity, poolSize: 10 }),
+    ).toBe(0)
+  })
+
+  it('returns 0 when poolSize is Infinity', () => {
+    expect(
+      responseAdDisplayCount({ eligibleCount: 5, poolSize: Infinity }),
+    ).toBe(0)
+  })
+
+  it('returns 0 when both inputs are negative', () => {
+    expect(
+      responseAdDisplayCount({ eligibleCount: -5, poolSize: -10 }),
+    ).toBe(0)
+  })
+
+  it('floors fractional inputs', () => {
+    expect(
+      responseAdDisplayCount({ eligibleCount: 5.7, poolSize: 3.2 }),
+    ).toBe(3)
+  })
+})

--- a/common/src/util/lazy-response-ads.ts
+++ b/common/src/util/lazy-response-ads.ts
@@ -16,8 +16,10 @@ export function responseAdDisplayCount(params: {
   eligibleCount: number
   poolSize: number
 }): number {
-  const eligibleCount = Math.max(0, Math.floor(params.eligibleCount))
-  const poolSize = Math.max(0, Math.floor(params.poolSize))
+  const safeEligibleCount = Number.isFinite(params.eligibleCount) ? params.eligibleCount : 0
+  const safePoolSize = Number.isFinite(params.poolSize) ? params.poolSize : 0
+  const eligibleCount = Math.max(0, Math.floor(safeEligibleCount))
+  const poolSize = Math.max(0, Math.floor(safePoolSize))
   return poolSize >= MAX_RESPONSE_AD_POOL_SIZE
     ? eligibleCount
     : Math.min(eligibleCount, poolSize)


### PR DESCRIPTION
## Overview
Fix NaN/Infinity handling in the `responseAdDisplayCount` function in `common/src/util/lazy-response-ads.ts` with comprehensive test coverage.

## Bug Description
The function used `Math.floor()` without checking if the input was a valid number. If `params.eligibleCount` or `params.poolSize` was NaN or Infinity, `Math.floor()` would return NaN, and `Math.max(0, NaN)` would return NaN, causing incorrect results.

## Fix
Added `Number.isFinite()` checks to default to 0 for invalid numbers.

## Testing
Added comprehensive test coverage with 8 test cases:
1. Returns eligibleCount when poolSize is at or above the max
2. Clamps to poolSize when poolSize is below the max
3. Returns 0 when eligibleCount is NaN
4. Returns 0 when poolSize is NaN
5. Returns 0 when eligibleCount is Infinity
6. Returns 0 when poolSize is Infinity
7. Returns 0 when both inputs are negative
8. Floors fractional inputs

All 8 tests pass.

## Files Changed
- `common/src/util/lazy-response-ads.ts` - Added NaN/Infinity validation
- `common/src/util/__tests__/lazy-response-ads.test.ts` - New test file with 8 test cases

## Scope
This change only touches `common/` which is an approved contribution area per the Contributing Guide.