### PR TITLE
Add missing test/setup-scm-loader.ts preload for .scm imports

### DIFF
--- a/cli/src/__tests__/scm-loader.test.ts
+++ b/cli/src/__tests__/scm-loader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+
+import goQuery from '../../../packages/code-map/src/tree-sitter-queries/tree-sitter-go-tags.scm'
+
+/**
+ * Guards test/setup-scm-loader.ts (registered as a preload in
+ * cli/bunfig.toml). Without it, importing any module that reaches
+ * @codebuff/sdk — which re-exports code-map, which imports .scm
+ * tree-sitter query files — dies at import time with "Unknown file type",
+ * which bun reports as an unhandled error between tests rather than a
+ * failure (see docs/testing.md). This file imports a .scm directly: if the
+ * preload is missing or regresses, the whole file fails to load instead of
+ * passing vacuously.
+ */
+describe('setup-scm-loader preload', () => {
+  test('loads .scm imports as strings', () => {
+    expect(typeof goQuery).toBe('string')
+    expect(goQuery.length).toBeGreaterThan(0)
+    // Tree-sitter queries capture nodes with @capture names; the go tags
+    // query is nontrivial, so this also proves the content came through
+    // intact rather than as an empty stub.
+    expect(goQuery).toContain('@')
+  })
+})

--- a/test/setup-scm-loader.ts
+++ b/test/setup-scm-loader.ts
@@ -1,0 +1,29 @@
+/**
+ * Bun preload: teach bun to import .scm (tree-sitter query) files as text.
+ *
+ * packages/code-map/src/languages.ts imports .scm files directly, and the SDK
+ * barrel re-exports code-map — so any test importing @codebuff/sdk (or the CLI
+ * modules that reach it) needs this registered before those imports evaluate.
+ *
+ * cli/bunfig.toml lists this preload, but the file itself was not present in
+ * the public mirror, so sdk-touching tests died at import time ("Unknown file
+ * type" for the first .scm import), which bun reports as an unhandled error
+ * between tests rather than a test failure (see docs/testing.md).
+ *
+ * The bundled build handles .scm imports the same way: loader 'text', default
+ * export is the file's contents as a string.
+ */
+import { plugin } from 'bun'
+import { readFileSync } from 'fs'
+
+plugin({
+  name: 'scm-text-loader',
+  setup(build) {
+    build.onLoad({ filter: /\.scm$/ }, (args) => ({
+      // Wrap in a JS module: bun's plugin API only accepts code loaders
+      // (js/json/...), and the import sites expect a default-exported string.
+      contents: `export default ${JSON.stringify(readFileSync(args.path, 'utf8'))}`,
+      loader: 'js' as const,
+    }))
+  },
+})


### PR DESCRIPTION
## Problem
 
`cli/bunfig.toml` lists three test preloads:
 
    preload = [
      "../sdk/test/setup-env.ts",
      "../test/setup-scm-loader.ts",
      "./test/setup-agents-artifact.ts",
    ]
 
But `test/setup-scm-loader.ts` does not exist in the public mirror. Any test that
reaches `@codebuff/sdk` (which re-exports code-map, which imports `.scm`
tree-sitter query files) dies at import time with "Unknown file type" — which bun
reports as "Unhandled error between tests", so a fresh clone shows a wall of
failing test files with no obvious cause. (The same file is referenced in
docs/testing.md, there under a corrupted path `../test/n.ts`.)
 
## Fix
 
One new file: a bun `plugin()` that loads `.scm` imports as a default-exported
string — the same thing the bundled build does. Registered via the preload that
bunfig.toml already declares, so no config change is needed.
 
## Verification
 
`cd cli && bun test src/commands src/utils/__tests__ src/state`:
 
- **1,576 pass** with this change
- 13 failures remain, all pre-existing Windows path-separator issues in
  export-conversation.test.ts (expects `/project/...`, gets `\project\...`) —
  present on main without this change, happy to file a separate issue for those
 
Tested on Windows 11 / bun 1.3.14.
