### PR TITLE
Drop tool results orphaned by trimMessagesToFitTokenLimit at the removal boundary

### DIFF
--- a/packages/agent-runtime/src/util/__tests__/messages.test.ts
+++ b/packages/agent-runtime/src/util/__tests__/messages.test.ts
@@ -511,6 +511,175 @@ describe('trimMessagesToFitTokenLimit', () => {
       expect(replacementMessages.length).toBeGreaterThan(0)
     })
   })
+
+  describe('orphaned tool results at the removal boundary', () => {
+    // Regression: the removal run stops as soon as the token budget is met,
+    // which can land exactly between an assistant tool-call and its result.
+    // The kept tool message then reaches the provider without its call and
+    // is rejected with "tool_call_id does not exist", failing the whole step.
+
+    const toolCallPart = (toolCallId: string, filler: string) => ({
+      type: 'tool-call' as const,
+      toolCallId,
+      toolName: 'write_file' as const,
+      input: { content: filler },
+    })
+
+    const toolResultMessage = (
+      toolCallId: string,
+      filler: string,
+    ): Message => ({
+      role: 'tool',
+      toolName: 'write_file',
+      toolCallId,
+      content: jsonToolResult(filler),
+    })
+
+    /** Every tool result in the output must have its call in the output. */
+    const expectNoOrphanedToolResults = (result: Message[]) => {
+      const keptToolCallIds = new Set<string>()
+      for (const message of result) {
+        if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+          continue
+        }
+        for (const part of message.content) {
+          if (part.type === 'tool-call') {
+            keptToolCallIds.add(part.toolCallId)
+          }
+        }
+      }
+      const orphaned = result.filter(
+        (message) =>
+          message.role === 'tool' && !keptToolCallIds.has(message.toolCallId),
+      )
+      expect(orphaned).toEqual([])
+    }
+
+    it('drops a tool result whose call was removed at the boundary', () => {
+      const messages: Message[] = [
+        userMessage('please write the file'),
+        assistantMessage({
+          content: [toolCallPart('c1', 'x'.repeat(4000))],
+        }),
+        toolResultMessage('c1', 'ok'),
+        assistantMessage('done'),
+      ]
+
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 600,
+        logger,
+      })
+
+      expectNoOrphanedToolResults(result)
+      // The final 'done' assistant message must survive the trim.
+      expect(
+        result.some(
+          (message) =>
+            message.role === 'assistant' &&
+            message.content.some(
+              (part) => part.type === 'text' && part.text === 'done',
+            ),
+        ),
+      ).toBe(true)
+    })
+
+    it('drops tool results orphaned after a kept keepDuringTruncation message', () => {
+      // The removal run is not a pure prefix when keepDuringTruncation
+      // messages sit in the middle: the boundary orphan can appear anywhere,
+      // not just leading the kept run.
+      const messages: Message[] = [
+        userMessage('please write the file'),
+        assistantMessage({
+          content: [toolCallPart('c1', 'x'.repeat(4000))],
+        }),
+        userMessage({ content: 'steer', keepDuringTruncation: true }),
+        toolResultMessage('c1', 'ok'),
+        assistantMessage('done'),
+      ]
+
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 600,
+        logger,
+      })
+
+      expectNoOrphanedToolResults(result)
+    })
+
+    it('keeps tool results whose call survives the trim', () => {
+      const messages: Message[] = [
+        userMessage('please write the file'),
+        assistantMessage({
+          content: [toolCallPart('c1', 'x'.repeat(4000))],
+        }),
+        toolResultMessage('c1', 'ok'),
+        assistantMessage('done'),
+      ]
+
+      // Generous budget: nothing gets removed, pairing stays intact.
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 60_000,
+        logger,
+      })
+
+      expect(result).toEqual(messages)
+    })
+
+    it('leaves pre-existing orphans in an already-malformed history untouched', () => {
+      // The tool result has no call anywhere in the input: trimming did not
+      // create this orphan, so this fix leaves it alone instead of silently
+      // rewriting histories it did not break. The trim is active here (the
+      // large user message is removed) — only calls removed BY the trim
+      // cause their results to be dropped.
+      const messages: Message[] = [
+        userMessage('x'.repeat(4000)),
+        assistantMessage('done'),
+        toolResultMessage('ghost', 'ok'),
+      ]
+
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 600,
+        logger,
+      })
+
+      const ghost = result.find(
+        (message) => message.role === 'tool' && message.toolCallId === 'ghost',
+      )
+      expect(ghost).toBeDefined()
+    })
+
+    it('keeps the invariant across a sweep of budgets', () => {
+      const messages: Message[] = [
+        userMessage('please write the file'),
+        assistantMessage({
+          content: [toolCallPart('c1', 'x'.repeat(3000))],
+        }),
+        toolResultMessage('c1', 'ok'),
+        assistantMessage({
+          content: [toolCallPart('c2', 'y'.repeat(1500))],
+        }),
+        toolResultMessage('c2', 'ok'),
+        assistantMessage('done'),
+      ]
+
+      for (const maxTotalTokens of [200, 400, 800, 1600, 3200, 6400]) {
+        const result = trimMessagesToFitTokenLimit({
+          messages,
+          systemTokens: 0,
+          maxTotalTokens,
+          logger,
+        })
+        expectNoOrphanedToolResults(result)
+      }
+    })
+  })
 })
 
 describe('getPreviouslyReadFiles', () => {

--- a/packages/agent-runtime/src/util/__tests__/messages.test.ts
+++ b/packages/agent-runtime/src/util/__tests__/messages.test.ts
@@ -655,6 +655,84 @@ describe('trimMessagesToFitTokenLimit', () => {
       expect(ghost).toBeDefined()
     })
 
+    it('drops only the orphaned results when one assistant message carries multiple tool calls', () => {
+      // Parallel tool calls: a single assistant message with calls c1 and c2.
+      // The trim removes the call message; the drop matches per toolCallId, so
+      // every result whose call was removed is dropped and nothing keyed to a
+      // surviving call is touched.
+      const messages: Message[] = [
+        userMessage('write two files'),
+        assistantMessage({
+          content: [
+            toolCallPart('c1', 'x'.repeat(3000)),
+            toolCallPart('c2', 'y'.repeat(3000)),
+          ],
+        }),
+        toolResultMessage('c1', 'ok1'),
+        userMessage({ content: 'steer', keepDuringTruncation: true }),
+        toolResultMessage('c2', 'ok2'),
+        assistantMessage('done'),
+      ]
+
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 600,
+        logger,
+      })
+
+      expectNoOrphanedToolResults(result)
+      // Neither orphaned result may survive in any form...
+      expect(
+        result.filter(
+          (message) =>
+            message.role === 'tool' &&
+            (message.toolCallId === 'c1' || message.toolCallId === 'c2'),
+        ),
+      ).toEqual([])
+      // ...while the kept steer message and the final reply still do.
+      expect(
+        result.some(
+          (message) =>
+            message.role === 'user' &&
+            message.content.some(
+              (part) => part.type === 'text' && part.text === 'steer',
+            ),
+        ),
+      ).toBe(true)
+      expect(
+        result.some(
+          (message) =>
+            message.role === 'assistant' &&
+            message.content.some(
+              (part) => part.type === 'text' && part.text === 'done',
+            ),
+        ),
+      ).toBe(true)
+    })
+
+    it('keeps every result of a multi-call assistant message that survives the trim', () => {
+      const messages: Message[] = [
+        userMessage('write two files'),
+        assistantMessage({
+          content: [toolCallPart('c1', 'ok'), toolCallPart('c2', 'ok')],
+        }),
+        toolResultMessage('c1', 'ok1'),
+        toolResultMessage('c2', 'ok2'),
+        assistantMessage('done'),
+      ]
+
+      // Generous budget: the multi-call message and both results survive.
+      const result = trimMessagesToFitTokenLimit({
+        messages,
+        systemTokens: 0,
+        maxTotalTokens: 60_000,
+        logger,
+      })
+
+      expect(result).toEqual(messages)
+    })
+
     it('keeps the invariant across a sweep of budgets', () => {
       const messages: Message[] = [
         userMessage('please write the file'),

--- a/packages/agent-runtime/src/util/messages.ts
+++ b/packages/agent-runtime/src/util/messages.ts
@@ -234,7 +234,10 @@ export function trimMessagesToFitTokenLimit(params: {
   // then reaches the provider without its call and is rejected with
   // "tool_call_id does not exist", failing the whole step. Drop results whose
   // call this trim removed — but only those, so orphans that were already in
-  // the input history pass through unchanged.
+  // the input history pass through unchanged. This also overrides
+  // keepDuringTruncation on a tool result whose call was removed: keeping the
+  // pair together would exceed the budget and keeping the result alone would
+  // be rejected, so a result cannot outlive its call.
   const removedCallIds = new Set<string>()
   const survivingCallIds = new Set<string>()
   const collectCallIds = (message: Message, into: Set<string>) => {

--- a/packages/agent-runtime/src/util/messages.ts
+++ b/packages/agent-runtime/src/util/messages.ts
@@ -229,6 +229,44 @@ export function trimMessagesToFitTokenLimit(params: {
     }
   }
 
+  // The removal run stops as soon as the token budget is met, which can land
+  // between an assistant tool-call and its result: the surviving tool message
+  // then reaches the provider without its call and is rejected with
+  // "tool_call_id does not exist", failing the whole step. Drop results whose
+  // call this trim removed — but only those, so orphans that were already in
+  // the input history pass through unchanged.
+  const removedCallIds = new Set<string>()
+  const survivingCallIds = new Set<string>()
+  const collectCallIds = (message: Message, into: Set<string>) => {
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      return
+    }
+    for (const part of message.content) {
+      if (part.type === 'tool-call' && part.providerExecuted !== true) {
+        into.add(part.toolCallId)
+      }
+    }
+  }
+  for (const message of messages) {
+    collectCallIds(message, removedCallIds)
+  }
+  if (removedCallIds.size > 0) {
+    for (const message of filteredMessages) {
+      if (message === placeholder) continue
+      collectCallIds(message, survivingCallIds)
+    }
+    for (let i = filteredMessages.length - 1; i >= 0; i--) {
+      const message = filteredMessages[i]
+      if (message === placeholder || message.role !== 'tool') continue
+      if (
+        removedCallIds.has(message.toolCallId) &&
+        !survivingCallIds.has(message.toolCallId)
+      ) {
+        filteredMessages.splice(i, 1)
+      }
+    }
+  }
+
   return filteredMessages.map((m) =>
     m === placeholder ? replacementMessage : m,
   )

--- a/packages/agent-runtime/src/util/messages.ts
+++ b/packages/agent-runtime/src/util/messages.ts
@@ -238,7 +238,7 @@ export function trimMessagesToFitTokenLimit(params: {
   // keepDuringTruncation on a tool result whose call was removed: keeping the
   // pair together would exceed the budget and keeping the result alone would
   // be rejected, so a result cannot outlive its call.
-  const removedCallIds = new Set<string>()
+  const inputCallIds = new Set<string>()
   const survivingCallIds = new Set<string>()
   const collectCallIds = (message: Message, into: Set<string>) => {
     if (message.role !== 'assistant' || !Array.isArray(message.content)) {
@@ -251,9 +251,9 @@ export function trimMessagesToFitTokenLimit(params: {
     }
   }
   for (const message of messages) {
-    collectCallIds(message, removedCallIds)
+    collectCallIds(message, inputCallIds)
   }
-  if (removedCallIds.size > 0) {
+  if (inputCallIds.size > 0) {
     for (const message of filteredMessages) {
       if (message === placeholder) continue
       collectCallIds(message, survivingCallIds)
@@ -262,7 +262,7 @@ export function trimMessagesToFitTokenLimit(params: {
       const message = filteredMessages[i]
       if (message === placeholder || message.role !== 'tool') continue
       if (
-        removedCallIds.has(message.toolCallId) &&
+        inputCallIds.has(message.toolCallId) &&
         !survivingCallIds.has(message.toolCallId)
       ) {
         filteredMessages.splice(i, 1)


### PR DESCRIPTION
## Problem & Context

`trimMessagesToFitTokenLimit` removes a contiguous run of oldest messages until the token budget is met — and the run can stop **exactly between an assistant message carrying tool-calls and its `role: 'tool'` results**. The surviving tool message then reaches the provider without its call and the whole step fails with `tool_call_id does not exist` (observed on the openai-compatible lane; consumed via `getMessagesSubset` by `find-files/request-files-prompt.ts:201,271`).

Reproduction (pre-fix, against the real module):

```
messages = [
  userMessage('please write the file'),
  assistantMessage({ content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'write_file', input: { content: 'x'.repeat(4000) } }] }),
  { role: 'tool', toolName: 'write_file', toolCallId: 'c1', content: jsonToolResult('ok') },
  assistantMessage('done'),
]
trimMessagesToFitTokenLimit({ messages, systemTokens: 0, maxTotalTokens: 600, ... })
→ output roles: ["user", "user", "tool", "assistant"]   // "tool" has no preceding call → provider 400
```

`dropUnansweredToolCalls` at the conversion chokepoint intentionally handles only the mirror case (calls whose results are gone) — orphaned *results* were the gap.

## Changes Made

- `packages/agent-runtime/src/util/messages.ts` (`trimMessagesToFitTokenLimit`): after the removal loop, drop any surviving `role: 'tool'` message whose `toolCallId` was present in the input history but is not provided by any surviving assistant message. +38 lines, no other behavior touched.
- `packages/agent-runtime/src/util/__tests__/messages.test.ts`: five regression/behavior-preservation tests importing the real production function.

Deliberate scoping: only results orphaned **by this trim** are dropped (their call existed in the input and was removed). Orphans already present in a malformed input history pass through unchanged, as before — this fix does not silently rewrite histories it did not break. `providerExecuted` calls are excluded from both sets, mirroring the pairing semantics of `dropUnansweredToolCalls`.

## Architecture & Conventions Conformance

- [x] Adheres to Dependency Injection (contracts defined in `common/src/types/contracts/`, no module monkey patching) — pure function change, logger injected as before
- [x] Terminal commands use `terminalCommandBroker` (no direct `spawn` or TUI-process bypass) — no process execution touched
- [x] Environment hygiene respected (`getCliEnv()` for CLI, `getSdkEnv()` for SDK, no forbidden `getProcessEnv()` imports) — no env access added
- [x] Freebuff mode compatibility (`IS_FREEBUFF` preserved, no paid features introduced) — product-agnostic bug fix
- [x] Imports ordered and explicit (`import type` used for types) — no import changes

## Scope Verification

- [x] All modified files are within allowed public directories: `packages/agent-runtime/`
- [x] NO modifications to `web/`, `freebuff/web/`, `packages/internal/`, `packages/billing/`, `packages/bigquery/`, or `packages/build-tools/`

## Testing & Verification

- [x] `bun run build:sdk` (passed cleanly)
- [x] `bun run build:freebuff` (passed cleanly)
- [x] `bun cli/scripts/smoke-binary.ts cli/bin/freebuff` (passed cleanly — with the CI env var set and a writable `HOME`; the sandboxed checkout has a read-only home directory)
- [x] Unit / integration tests added or updated in affected package
- [x] Anti-flake principles observed (no sleeps, no ports, no filesystem, no timers; the budget-sweep test asserts a structural invariant rather than fragile token arithmetic)

Tests were proven to catch the bug: with the fix stashed, 3 of the new tests fail against the unfixed source (boundary orphan, keepDuringTruncation-interleaved orphan, budget sweep); with the fix applied, all 32 tests in the file pass. Fix and tests were additionally verified by an independent adversarial pass (targeted attacks over duplicate call ids, multi-call assistant messages, `providerExecuted` asymmetry, keepDuringTruncation interaction, input-mutation checks, early-return path, plus a seeded property fuzz ≥ 3000 histories): every surviving tool result either has its call, was a pre-existing orphan, or is `providerExecuted`-related; input never mutated; no new failures.

### Verification Output / Log Snippet

```
$ bun test packages/agent-runtime/src/util/__tests__/messages.test.ts
 32 pass
 0 fail
 92 expect() calls
Ran 32 tests across 1 file. [454.00ms]

$ bun run --cwd packages/agent-runtime test
 597 pass / 5 fail  (identical to main baseline: MCP schema ×2 = #1259, find-files WIP ×1-2 — not this change)

$ bun run --cwd packages/agent-runtime typecheck
 0 new errors (2 agents-graveyard = #1202; 1 from uncommitted find-files WIP, not this branch's files)

$ bun cli/scripts/smoke-binary.ts cli/bin/freebuff
 smoke-binary: tree-sitter init OK.
 smoke-binary: OK (matched /\x1b\[\?1049h/, exit code null, 9176 bytes captured, attempt 1/3).
```

New tests (all against the production module, no local reimplementations):

1. `drops a tool result whose call was removed at the boundary` — the reported 400 case; also asserts the final `'done'` assistant message survives
2. `drops tool results orphaned after a kept keepDuringTruncation message` — removal runs are not pure prefixes when `keepDuringTruncation` messages sit mid-run, so the orphan can appear anywhere, not just leading the kept run
3. `keeps tool results whose call survives the trim` (no-trim passthrough)
4. `leaves pre-existing orphans in an already-malformed history untouched` (scoping guard, under an active trim)
5. `keeps the invariant across a sweep of budgets` (six budgets × two call pairs, structural assertion)
