### PR TITLE
fix(sdk): handle cyclic run-state on session resume

### DIFF
--- a/sdk/src/__tests__/run-state-git-changes.test.ts
+++ b/sdk/src/__tests__/run-state-git-changes.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 
 import { describe, expect, it } from 'bun:test'
+import z from 'zod/v4'
 
 import {
   applyOverridesToSessionState,
@@ -193,6 +194,78 @@ describe('repository snapshot persistence', () => {
     expect(continuedSessionState.fileContext.knowledgeFiles).toEqual({
       'AGENTS.md': 'Updated instructions',
     })
+  })
+
+  it('clones a resumed state whose run state carries a cycle', async () => {
+    // Resuming used to die on the second interaction with "JSON.stringify
+    // cannot serialize cyclic structures". The state carries the previous
+    // turn's tool blocks, and a recursive zod `lazy` schema in one of them is
+    // self-referential, so the clone has to survive a cycle.
+    const baseSessionState = getInitialSessionState(getStubProjectFileContext())
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    ;(baseSessionState.mainAgentState as any).output = circular
+
+    const continuedSessionState = await applyOverridesToSessionState(
+      '/repo',
+      baseSessionState,
+      { maxAgentSteps: 7 },
+    )
+
+    // The overrides still apply...
+    expect(continuedSessionState.mainAgentState.stepsRemaining).toBe(7)
+    // ...and the result is an independent copy whose cycle came across intact.
+    expect(continuedSessionState.mainAgentState).not.toBe(
+      baseSessionState.mainAgentState,
+    )
+    const clonedOutput = (continuedSessionState.mainAgentState as any).output
+    expect(clonedOutput.self).toBe(clonedOutput)
+  })
+
+  it('keeps a live zod schema intact when the fallback clone runs', async () => {
+    // The fallback runs exactly when the state is cyclic, and what makes it
+    // cyclic is a zod schema: mcp.ts stores MCP tools as live zod schemas, and
+    // a zod schema is self-referential. lodash copies own *enumerable*
+    // properties only, while zod keeps its internals on a non-enumerable
+    // `_zod`, so a plain cloneDeep hands back something that still looks like a
+    // schema -- `safeParse` comes from the prototype -- but throws on the first
+    // zod call with "undefined is not an object (evaluating '_zod.parent')".
+    const schema = z.object({ path: z.string() })
+    const baseSessionState = getInitialSessionState(getStubProjectFileContext())
+    const circular: Record<string, unknown> = { schema }
+    circular.self = circular
+    ;(baseSessionState.mainAgentState as any).output = circular
+
+    const continuedSessionState = await applyOverridesToSessionState(
+      '/repo',
+      baseSessionState,
+      {},
+    )
+
+    const clonedSchema = (continuedSessionState.mainAgentState as any).output
+      .schema
+    expect(clonedSchema._zod).toBeDefined()
+    expect(z.toJSONSchema(clonedSchema, { io: 'input' })).toMatchObject({
+      type: 'object',
+    })
+  })
+
+  it('falls back to a deep copy for values JSON.stringify rejects (BigInt)', async () => {
+    // The fallback is broader than "cycles only": BigInt makes JSON.stringify
+    // throw too, and cloneDeep preserves it rather than dropping the key.
+    const baseSessionState = getInitialSessionState(getStubProjectFileContext())
+    ;(baseSessionState.mainAgentState as any).output = { token: 10n }
+
+    const continuedSessionState = await applyOverridesToSessionState(
+      '/repo',
+      baseSessionState,
+      {},
+    )
+
+    expect((continuedSessionState.mainAgentState as any).output.token).toBe(10n)
+    expect(continuedSessionState.mainAgentState).not.toBe(
+      baseSessionState.mainAgentState,
+    )
   })
 })
 

--- a/sdk/src/run-state.ts
+++ b/sdk/src/run-state.ts
@@ -13,7 +13,7 @@ import {
 } from '@codebuff/common/project-file-tree'
 import { getInitialSessionState } from '@codebuff/common/types/session-state'
 import { getErrorObject } from '@codebuff/common/util/error'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, cloneDeepWith } from 'lodash'
 import z from 'zod/v4'
 
 import { loadLocalAgents } from './agents/load-agents'
@@ -1098,6 +1098,33 @@ export function withMessageHistory({
 }
 
 /**
+ * True for a zod schema, which is the only kind of value a clone has to be
+ * careful with here.
+ */
+const isZodSchema = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as { safeParse?: unknown; _zod?: unknown }
+  return (
+    typeof candidate.safeParse === 'function' && candidate._zod !== undefined
+  )
+}
+
+/**
+ * Deep-clones a value without destroying the zod schemas inside it.
+ *
+ * zod installs its internals on a non-enumerable `_zod` property, and lodash
+ * copies own *enumerable* properties only. A plain `cloneDeep` therefore
+ * returns something that still looks like a schema -- `safeParse` lives on the
+ * prototype, so it survives -- but has lost `_zod`, and the next zod call on it
+ * throws "undefined is not an object (evaluating 'schema._zod.parent')".
+ * Schemas are immutable, so the clone keeps them as they are.
+ */
+export const cloneDeepPreservingZodSchemas = <T>(value: T): T =>
+  cloneDeepWith(value, (candidate) =>
+    isZodSchema(candidate) ? candidate : undefined,
+  )
+
+/**
  * Applies overrides to an existing session state, allowing specific fields to be updated
  * even when continuing from a previous run.
  */
@@ -1115,10 +1142,33 @@ export async function applyOverridesToSessionState(
     maxAgentSteps?: number
   },
 ): Promise<SessionState> {
-  // Deep clone to avoid mutating the original session state
-  const sessionState = JSON.parse(
-    JSON.stringify(baseSessionState),
-  ) as SessionState
+  // Deep clone to avoid mutating the original session state. The JSON
+  // round-trip is the fast path - it matches what a persisted snapshot looks
+  // like - but this state can hold values JSON.stringify rejects. A resumed
+  // session carries the tool blocks of the turn before it, and a recursive zod
+  // `lazy` schema is cyclic: stringifying it throws "cannot serialize cyclic
+  // structures" and the resume dies. lodash cloneDeep handles cycles, so fall
+  // back to it and keep the clone working instead of losing the session.
+  //
+  // The catch is deliberately not narrowed, but it is narrower than "any JSON
+  // failure": in practice the throw comes from a cycle or a BigInt. Values JSON
+  // merely drops or coerces - `undefined`, functions, symbols, Date, URL - do
+  // not throw, so they keep taking the JSON path exactly as they did before and
+  // never reach cloneDeep. The fallback therefore only runs where this function
+  // used to throw: it repairs the resume that used to fail rather than changing
+  // one that used to work. On that path cloneDeep keeps the whole graph, which
+  // is the safe side to err on, since the clone is this turn's working copy.
+  // It goes through cloneDeepPreservingZodSchemas rather than plain cloneDeep:
+  // the values that make this state cyclic are the live zod schemas of the
+  // previous turn's MCP tools, and lodash drops a schema's non-enumerable
+  // internals, leaving a schema-shaped object that throws on first use.
+  // Mirrors cloneSessionState, which falls back the same way in run.ts.
+  let sessionState: SessionState
+  try {
+    sessionState = JSON.parse(JSON.stringify(baseSessionState)) as SessionState
+  } catch {
+    sessionState = cloneDeepPreservingZodSchemas(baseSessionState)
+  }
 
   // Apply maxAgentSteps override
   if (overrides.maxAgentSteps !== undefined) {


### PR DESCRIPTION
Resubmission of #945, auto-closed when the repo history was rewritten — per @victorxheng, "not a judgment on this PR". Its base commit no longer exists, so this is re-applied on current `main` rather than rebased — the re-application itself brings no other change. The review feedback is addressed below.

Fixes a crash surfaced while testing #944 (the /undo and /redo feature): on the second interaction of a resumed session, the CLI died with

```
Error: JSON.stringify cannot serialize cyclic structures.
```

## The trigger (added after reproducing this in the product)

The state goes cyclic when an **MCP server is configured**. MCP tools live in the run state as *live zod schemas* — `mcp.ts` converts each server tool with `convertJsonSchemaToZod` — and a zod schema is self-referential: its `_zod` internals point back at the schema itself. `JSON.stringify` on that state therefore throws.

So the repro is one config file and two messages:

1. Put any server in `.agents/mcp.json`:

   ```json
   { "mcpServers": { "exa": { "type": "http", "url": "https://mcp.exa.ai/mcp" } } }
   ```
2. Start the CLI in a project and send a message. The turn that clones the run state dies with `JSON.stringify cannot serialize cyclic structures`.

Verified with a locally built binary, MCP server configured:

| build | run |
| --- | --- |
| this patch missing (tool-set copy already fixed, see #1342) | dies with `JSON.stringify cannot serialize cyclic structures` |
| this patch in | completes; turns go through |

With both patches missing, the error that shows up first is the tool-set one — `undefined is not an object (evaluating 'H._zod.parent')`, sent separately as #1342 — which is how I know the two are independent. Fixing that one is what surfaced this one.

## Root cause

`applyOverridesToSessionState` in `sdk/src/run-state.ts` deep-clones the session state with a JSON round-trip (`JSON.parse(JSON.stringify(...))`). The run state can carry cyclic values — a recursive zod `lazy` schema inside a tool block is self-referential — and `JSON.stringify` throws on cycles. So resuming a session whose run state holds such a schema crashes the resume path.

It is the **second** interaction that dies once an MCP server has supplied one, which is why it reads as intermittent — see the trigger section above for the shortest repro.

## Fix

Try the JSON path first; if it throws, fall back to a deep clone that handles cycles. This mirrors what `cloneSessionState` already does in the same file — no new deps, lodash is already imported.

### The fallback must keep zod schemas intact

The obvious fallback, a plain `cloneDeep`, would hand back a corpse, and that is not a hypothetical: **the values that make this state cyclic are the zod schemas themselves.**

zod installs its internals on a **non-enumerable** `_zod`. lodash copies own *enumerable* properties only, so it drops `_zod` — but the clone keeps the prototype, so `safeParse` survives and the result still answers `Object` and looks like a schema. It only blows up on the first zod call:

```
TypeError: undefined is not an object (evaluating 'schema._zod.parent')
```

Reproduced directly:

| | |
| --- | --- |
| `_zod` on the original | present |
| `_zod` on a plain `cloneDeep` copy | **absent** |
| `safeParse` on the copy | present — the trap |
| `schema.description` on the copy | throws `_zod.parent`, same as #1342 |

So the fallback goes through `cloneDeepPreservingZodSchemas`, which is `cloneDeepWith` plus one rule: a zod schema is passed through by reference instead of copied. Schemas are immutable, so there is nothing to copy — and it keeps the hazard from coming back through the same door if anything else in the state ever holds a schema.

## Response to the review

### 1. The bare `catch {}`

The review asked to check — "or at least comment" — whether other `JSON.stringify` failure modes (e.g. BigInt, `undefined`) could silently fall into the `cloneDeep` path with different semantics than intended.

Both were done. The answer is no, and it is narrower than it looks:

| Value | `JSON.stringify` | Path taken |
| --- | --- | --- |
| cycle | **throws** | falls back to the deep clone |
| `BigInt` | **throws** | falls back to the deep clone |
| `undefined`, function, symbol | no throw, key **dropped** | JSON path, unchanged |
| `Date`, `URL` | no throw, **coerced** | JSON path, unchanged |

Only a cycle or a BigInt throws, so anything JSON merely drops or coerces never reaches the fallback. The catch stays unnarrowed on purpose and the comment records why — including that the fallback only runs where this function used to throw, so it cannot change the semantics of anything that used to work. The BigInt case has a test.

### 2. No test was added

Added three regression tests in `sdk/src/__tests__/run-state-git-changes.test.ts`:

- `clones a resumed state whose run state carries a cycle` — it does not throw, the override still applies, and the copy is independent with the cycle intact.
- `falls back to a deep copy for values JSON.stringify rejects (BigInt)` — pins the second throw trigger above.
- `keeps a live zod schema intact when the fallback clone runs` — the schema still has `_zod` and still converts with `z.toJSONSchema`. It fails on `main`, and it would fail again if the schema rule were dropped from the fallback.

All fail on `main` and pass with the patch.

## Verification

Public CI builds the SDK and smoke-tests the binary, but it does not run the tests, so this was reproduced locally:

- `bun run --cwd sdk typecheck` — clean
- `bun run --cwd sdk test` — 618 pass, 1 fail

The failure is pre-existing and unrelated: `sponsored rooted filesystem > a failed directory guard cannot continue in the wrong ancestor` matches the English `mkdir: ... File exists` message, which GNU coreutils translates, so it fails on non-English machines and passes on the English CI runners. Untouched here, reported separately in #1340.

## Scope

Two files, +128/-5, no behaviour change on the normal path. `prettier` reports a pre-existing union-type diff at `run-state.ts:874` — byte-identical on `main`, and no workflow runs prettier, so it is left out.
