### PR TITLE
feat(cli): add -c/--continue alias and 'nothing to continue' notice

### DIFF
--- a/cli/src/__tests__/cli-args.test.ts
+++ b/cli/src/__tests__/cli-args.test.ts
@@ -178,4 +178,37 @@ describe('Freebuff CLI Argument Parsing', () => {
     expect(result.command).toBe('login')
     expect(result.initialPrompt).toBeNull()
   })
+
+  test('accepts -c as continue without a conversation id', () => {
+    const result = parseArgs({
+      argv: ['node', 'freebuff', '-c'],
+      isFreebuff: true,
+      version: '1.0.0',
+    })
+
+    expect(result.continue).toBe(true)
+    expect(result.continueId).toBeNull()
+  })
+
+  test('accepts --continue as continue without a conversation id', () => {
+    const result = parseArgs({
+      argv: ['node', 'freebuff', '--continue'],
+      isFreebuff: true,
+      version: '1.0.0',
+    })
+
+    expect(result.continue).toBe(true)
+    expect(result.continueId).toBeNull()
+  })
+
+  test('accepts -c with an explicit conversation id', () => {
+    const result = parseArgs({
+      argv: ['node', 'freebuff', '-c', 'abc-123'],
+      isFreebuff: true,
+      version: '1.0.0',
+    })
+
+    expect(result.continue).toBe(true)
+    expect(result.continueId).toBe('abc-123')
+  })
 })

--- a/cli/src/app.tsx
+++ b/cli/src/app.tsx
@@ -34,6 +34,10 @@ interface AppProps {
   hasInvalidCredentials: boolean
   fileTree: FileTreeNode[]
   continueChat: boolean
+  /** Raw `-c` / `--continue` flag from the CLI, before history-pick resume
+   *  folds in. Lets the landing screen distinguish "I asked to continue a
+   *  session" from "I resumed a historical conversation". */
+  continueRequested?: boolean
   continueChatId?: string
   initialMode?: AgentMode
   showProjectPicker: boolean
@@ -47,6 +51,7 @@ export const App = ({
   hasInvalidCredentials,
   fileTree,
   continueChat,
+  continueRequested,
   continueChatId,
   initialMode,
   showProjectPicker,
@@ -260,6 +265,7 @@ export const App = ({
       logoutMutation={logoutMutation}
       continueChat={effectiveContinueChat}
       continueChatId={effectiveContinueChatId}
+      continueRequested={continueRequested === true}
       authStatus={authStatus}
       initialMode={initialMode}
       gitRoot={gitRoot}
@@ -285,6 +291,7 @@ interface AuthedSurfaceProps {
   logoutMutation: ReturnType<typeof useAuthState>['logoutMutation']
   continueChat: boolean
   continueChatId: string | undefined
+  continueRequested: boolean
   authStatus: AuthStatus
   initialMode: AgentMode | undefined
   gitRoot: string | null | undefined
@@ -338,6 +345,7 @@ const AuthedSurfaceRoutes = ({
   setUser,
   logoutMutation,
   authStatus,
+  continueRequested,
   initialMode,
   gitRoot,
   onSwitchToGitRoot,
@@ -400,6 +408,7 @@ const AuthedSurfaceRoutes = ({
         failure={sessionFailure}
         lastRefund={lastRefund}
         refundPending={refundPending}
+        continueRequested={continueRequested}
       />
     )
   }

--- a/cli/src/cli-args.ts
+++ b/cli/src/cli-args.ts
@@ -54,7 +54,7 @@ export function parseArgs({
       .description('Freebuff - Free AI coding assistant')
       .version(version, '-v, --version', 'Print the CLI version')
       .option(
-        '--continue [conversation-id]',
+        '-c, --continue [conversation-id]',
         'Continue from a previous conversation (optionally specify a conversation id)',
       )
       .option(
@@ -80,7 +80,7 @@ export function parseArgs({
         'Remove any existing CLI log files before starting',
       )
       .option(
-        '--continue [conversation-id]',
+        '-c, --continue [conversation-id]',
         'Continue from a previous conversation (optionally specify a conversation id)',
       )
       .option(

--- a/cli/src/components/__tests__/freebuff-nothing-to-continue.test.tsx
+++ b/cli/src/components/__tests__/freebuff-nothing-to-continue.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { createTestRenderer } from '@opentui/core/testing'
+import { createRoot, flushSync } from '@opentui/react'
+import React from 'react'
+
+import {
+  FreebuffNothingToContinueNotice,
+  NOTHING_TO_CONTINUE_MESSAGE,
+} from '../freebuff-landing-screen'
+import { initializeThemeStore } from '../../hooks/use-theme'
+
+let cleanupRenderer: (() => void) | undefined
+
+beforeAll(() => {
+  initializeThemeStore()
+})
+
+afterEach(() => {
+  cleanupRenderer?.()
+  cleanupRenderer = undefined
+})
+
+const renderNotice = async () => {
+  const setup = await createTestRenderer({ width: 100, height: 3 })
+  const root = createRoot(setup.renderer)
+  cleanupRenderer = () => {
+    flushSync(() => root.unmount())
+    setup.renderer.destroy()
+  }
+  flushSync(() => root.render(<FreebuffNothingToContinueNotice />))
+  await setup.renderOnce()
+  return setup
+}
+
+describe('FreebuffNothingToContinueNotice', () => {
+  test('tells the user there is nothing to continue', async () => {
+    const setup = await renderNotice()
+    const frame = setup.captureCharFrame().replace(/\s+/g, ' ')
+
+    expect(frame).toContain('nothing to continue')
+    expect(frame).toContain('no active session was found')
+  })
+
+  test('mentions starting a new session as the way forward', async () => {
+    const setup = await renderNotice()
+
+    expect(setup.captureCharFrame()).toContain('Pick a model below to start')
+  })
+
+  test('wraps the message on a narrow terminal rather than clipping it', async () => {
+    const setup = await createTestRenderer({ width: 40, height: 4 })
+    const root = createRoot(setup.renderer)
+    cleanupRenderer = () => {
+      flushSync(() => root.unmount())
+      setup.renderer.destroy()
+    }
+    flushSync(() => root.render(<FreebuffNothingToContinueNotice />))
+    await setup.renderOnce()
+
+    const frame = setup.captureCharFrame().replace(/\s+/g, ' ')
+    expect(frame).toContain(NOTHING_TO_CONTINUE_MESSAGE.replace(/\s+/g, ' '))
+  })
+})

--- a/cli/src/components/freebuff-landing-screen.tsx
+++ b/cli/src/components/freebuff-landing-screen.tsx
@@ -69,6 +69,11 @@ interface FreebuffLandingScreenProps {
   failure: FreebuffSessionFailure | null
   lastRefund: number | null
   refundPending: boolean
+  /** True when the CLI was launched with `-c` / `--continue`. Drives the
+   *  "nothing to continue" notice: only a session resume can satisfy the
+   *  user's ask, so the landing screen has to say it found nothing rather
+   *  than behaving like a plain first launch. */
+  continueRequested?: boolean
 }
 
 /** Landing-screen heading. Referenced both as rendered text and by the
@@ -76,6 +81,22 @@ interface FreebuffLandingScreenProps {
  *  the two from drifting. */
 const LANDING_HEADING = 'Start coding for free'
 const COLLAPSED_LOGO_MIN_HEIGHT = 26
+
+/** Shown on the landing screen when the user launched with `-c` /
+ *  `--continue` but the probe found no active session to resume (no seat,
+ *  expired, or explicitly ended). Exported so the render test can mount it
+ *  without the landing screen's ad/streak/logo machinery. */
+export const NOTHING_TO_CONTINUE_MESSAGE =
+  "There's nothing to continue — no active session was found. Pick a model below to start a new one."
+
+export const FreebuffNothingToContinueNotice: React.FC = () => {
+  const theme = useTheme()
+  return (
+    <text style={{ fg: theme.secondary, wrapMode: 'word', marginTop: 1 }}>
+      {NOTHING_TO_CONTINUE_MESSAGE}
+    </text>
+  )
+}
 
 /** "in ~3h 20m" / "in ~45 min" / "in under a minute". Used on the
  *  rate-limited screen so users know when they can try again. */
@@ -358,6 +379,7 @@ export const FreebuffLandingScreen: React.FC<FreebuffLandingScreenProps> = ({
   failure,
   lastRefund,
   refundPending,
+  continueRequested,
 }) => {
   const theme = useTheme()
   const renderer = useRenderer()
@@ -593,9 +615,18 @@ export const FreebuffLandingScreen: React.FC<FreebuffLandingScreenProps> = ({
   // scrollbox is measured by the selector itself and must NOT be reserved
   // here as well, or the viewport shrinks while the content grows.
   const belowPickerRows = streakRows + noticeRows + streakBonusRows
+  // The continue notice renders above the picker, so its rows must be carved
+  // out of the picker's viewport budget the way the heading's are.
+  const continueNoticeRows =
+    continueRequested && isLanding
+      ? 1 /* marginTop */ + wrappedRows(NOTHING_TO_CONTINUE_MESSAGE)
+      : 0
   const reservedChrome = 2 + adRows + 1 /* main paddingBottom */ + logoBlockRows
   const landingTextRows =
-    wrappedRows(LANDING_HEADING) + textMarginBottom + belowPickerRows
+    wrappedRows(LANDING_HEADING) +
+    textMarginBottom +
+    continueNoticeRows +
+    belowPickerRows
   // Floor = one whole recommended card: 2 border rows + its 2 text lines (name
   // + tagline, then the AI-training warning on its own line). Rows grew from
   // one text line to two when the warning stopped inlining, so the old floor of
@@ -726,6 +757,7 @@ export const FreebuffLandingScreen: React.FC<FreebuffLandingScreenProps> = ({
                   onDismiss={freebucksIntro.dismiss}
                 />
               )}
+              {continueRequested && <FreebuffNothingToContinueNotice />}
               <LandingHeadingRow
                 streakLine={streakOnHeadingRow ? streakLine : null}
                 marginBottom={textMarginBottom}

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -378,6 +378,7 @@ async function main(): Promise<void> {
         hasInvalidCredentials={hasInvalidCredentials}
         fileTree={fileTree}
         continueChat={continueChat}
+        continueRequested={continueChat}
         continueChatId={continueId ?? undefined}
         initialMode={initialMode}
         showProjectPicker={showProjectPickerScreen}


### PR DESCRIPTION
## Summary

Implements part of the ask in #1338: `freebuff -c` (and the long form `freebuff --continue`) now resume an active session instead of wasting the remaining time when the CLI crashed, the terminal closed, or an update interrupted the previous run.

### Changes

- **`cli/src/cli-args.ts`** — added the `-c` short alias to `--continue [conversation-id]` (freebuff and codebuff parsers).
- **`cli/src/index.tsx` / `cli/src/app.tsx`** — thread the raw `continueRequested` flag (distinct from history-pick resume) down to the landing screen.
- **`cli/src/components/freebuff-landing-screen.tsx`** — when `--continue` was requested but the session probe finds no active seat to resume (`none`, expired, or explicitly ended), the landing screen now clearly says there is nothing to continue. Rows are accounted for in the picker's height budget.
- Tests for flag parsing (`cli-args.test.ts`) and the notice render (`freebuff-nothing-to-continue.test.tsx`).

### Resume behavior

The actual session resume relies on the existing free session infra: on startup the probe auto-takes over the server seat when the prior local process is dead (the crash/terminal-close/update case), which preserves the server session and its remaining time, while `--continue` restores the previous conversation state. When the seat is held by a live process, the existing "Take over" confirmation is shown rather than silently superseding it.

### Verification

- New + adjacent tests pass; full `cli` suite has no new failures (the 21 failures/19 errors are pre-existing at HEAD: missing private `packages/internal` env + release-wrapper checks).
- Typecheck clean for the touched files (only pre-existing `tar`/`react-dom/server` declaration errors remain).

Closes #1338